### PR TITLE
Add `save_to` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## vNext
+
+- Add ability to save intermediate results to disk when fetching data across multiple requests using `save_to` parameter
+
 ## v0.14.0 - Nov 8, 2022
 
 - Add `get_capacity_prices` to NYISO

--- a/gridstatus/__init__.py
+++ b/gridstatus/__init__.py
@@ -14,6 +14,8 @@ from gridstatus.base import Markets, NotSupported
 
 import gridstatus.utils
 
+from gridstatus.utils import load_folder
+
 from gridstatus.nyiso import NYISO
 from gridstatus.caiso import CAISO
 from gridstatus.ercot import Ercot
@@ -38,4 +40,5 @@ __all__ = [
     "list_isos",
     "get_interconnection_queues",
     "NotSupported",
+    "load_folder",
 ]

--- a/gridstatus/decorators.py
+++ b/gridstatus/decorators.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import pprint
 
 import pandas as pd
@@ -85,6 +86,13 @@ class support_date_range:
                 args_dict["end"] = gridstatus.utils._handle_date(
                     args_dict["end"],
                     args_dict["self"].default_timezone,
+                )
+
+                assert (
+                    args_dict["end"] > args_dict["date"]
+                ), "End date {} must be after start date {}".format(
+                    args_dict["end"],
+                    args_dict["date"],
                 )
 
             # use .date() to remove timezone info, which doesnt matter if just a date
@@ -197,22 +205,22 @@ class support_date_range:
 def _handle_save_to(df, save_to, args_dict, f):
     if df is not None and save_to is not None:
         if "end" in args_dict:
-            filename = "{}/{}_{}_{}_{}.csv".format(
-                save_to,
+            filename = "{}_{}_{}_{}.csv".format(
                 args_dict["self"].__class__.__name__,
                 f.__name__,
                 args_dict["date"].strftime("%Y%m%d"),
                 args_dict["end"].strftime("%Y%m%d"),
             )
         else:
-            filename = "{}/{}_{}_{}.csv".format(
-                save_to,
+            filename = "{}_{}_{}.csv".format(
                 args_dict["self"].__class__.__name__,
                 f.__name__,
                 args_dict["date"].strftime("%Y%m%d"),
             )
 
-        df.to_csv(filename, index=None)
+        path = os.path.join(save_to, filename)
+
+        df.to_csv(path, index=None)
 
 
 def _get_pjm_archive_date(market):

--- a/gridstatus/decorators.py
+++ b/gridstatus/decorators.py
@@ -29,7 +29,7 @@ class support_date_range:
             if "save_to" in args_dict:
                 save_to = args_dict.pop("save_to")
 
-            error = "raise"
+            error = "ignore"
             errors = []
             if "error" in args_dict:
                 error = args_dict.pop("error")

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -429,3 +429,9 @@ def test_date_or_start(iso):
 
     with pytest.raises(ValueError):
         iso.get_fuel_mix(start=start.date(), date=start.date())
+
+
+def test_end_before_start_raises_error():
+    iso = CAISO()
+    with pytest.raises(AssertionError):
+        iso.get_fuel_mix(start="Jan 2, 2021", end="Jan 1, 2021")

--- a/gridstatus/tests/test_save_to.py
+++ b/gridstatus/tests/test_save_to.py
@@ -12,13 +12,13 @@ def test_save_to_one_day_per_request(tmp_path):
         save_to=tmp_path,
     )
 
-    files = os.listdir(tmp_path)
+    files = sorted(os.listdir(tmp_path))
 
     assert len(files) == 3
     assert files == [
+        "CAISO_get_fuel_mix_20220101.csv",
         "CAISO_get_fuel_mix_20220102.csv",
         "CAISO_get_fuel_mix_20220103.csv",
-        "CAISO_get_fuel_mix_20220101.csv",
     ]
 
     df_2 = gridstatus.load_folder(tmp_path)
@@ -35,12 +35,12 @@ def test_save_to_with_date_range_requests(tmp_path):
         save_to=tmp_path,
     )
 
-    files = os.listdir(tmp_path)
+    files = sorted(os.listdir(tmp_path))
 
     assert len(files) == 2
     assert files == [
-        "NYISO_get_fuel_mix_20220201_20220202.csv",
         "NYISO_get_fuel_mix_20220130_20220201.csv",
+        "NYISO_get_fuel_mix_20220201_20220202.csv",
     ]
 
     df_2 = gridstatus.load_folder(tmp_path)

--- a/gridstatus/tests/test_save_to.py
+++ b/gridstatus/tests/test_save_to.py
@@ -21,6 +21,10 @@ def test_save_to_one_day_per_request(tmp_path):
         "CAISO_get_fuel_mix_20220101.csv",
     ]
 
+    df_2 = gridstatus.load_folder(tmp_path)
+
+    assert (df == df_2).all().all()
+
 
 def test_save_to_with_date_range_requests(tmp_path):
     iso = gridstatus.NYISO()
@@ -38,3 +42,6 @@ def test_save_to_with_date_range_requests(tmp_path):
         "NYISO_get_fuel_mix_20220201_20220202.csv",
         "NYISO_get_fuel_mix_20220130_20220201.csv",
     ]
+
+    df_2 = gridstatus.load_folder(tmp_path)
+    assert (df == df_2).all().all()

--- a/gridstatus/tests/test_save_to.py
+++ b/gridstatus/tests/test_save_to.py
@@ -12,14 +12,16 @@ def test_save_to_one_day_per_request(tmp_path):
         save_to=tmp_path,
     )
 
-    files = sorted(os.listdir(tmp_path))
+    files = set(os.listdir(tmp_path))
 
     assert len(files) == 3
-    assert files == [
-        "CAISO_get_fuel_mix_20220101.csv",
-        "CAISO_get_fuel_mix_20220102.csv",
-        "CAISO_get_fuel_mix_20220103.csv",
-    ]
+    assert files == set(
+        [
+            "CAISO_get_fuel_mix_20220101.csv",
+            "CAISO_get_fuel_mix_20220102.csv",
+            "CAISO_get_fuel_mix_20220103.csv",
+        ],
+    )
 
     df_2 = gridstatus.load_folder(tmp_path)
 
@@ -35,13 +37,15 @@ def test_save_to_with_date_range_requests(tmp_path):
         save_to=tmp_path,
     )
 
-    files = sorted(os.listdir(tmp_path))
+    files = set(os.listdir(tmp_path))
 
     assert len(files) == 2
-    assert files == [
-        "NYISO_get_fuel_mix_20220130_20220201.csv",
-        "NYISO_get_fuel_mix_20220201_20220202.csv",
-    ]
+    assert files == set(
+        [
+            "NYISO_get_fuel_mix_20220130_20220201.csv",
+            "NYISO_get_fuel_mix_20220201_20220202.csv",
+        ],
+    )
 
     df_2 = gridstatus.load_folder(tmp_path)
     assert (df == df_2).all().all()

--- a/gridstatus/tests/test_save_to.py
+++ b/gridstatus/tests/test_save_to.py
@@ -1,0 +1,40 @@
+import os
+
+import gridstatus
+
+
+def test_save_to_one_day_per_request(tmp_path):
+    iso = gridstatus.CAISO()
+
+    df = iso.get_fuel_mix(
+        start="Jan 1, 2022",
+        end="Jan 4, 2022",
+        save_to=tmp_path,
+    )
+
+    files = os.listdir(tmp_path)
+
+    assert len(files) == 3
+    assert files == [
+        "CAISO_get_fuel_mix_20220102.csv",
+        "CAISO_get_fuel_mix_20220103.csv",
+        "CAISO_get_fuel_mix_20220101.csv",
+    ]
+
+
+def test_save_to_with_date_range_requests(tmp_path):
+    iso = gridstatus.NYISO()
+
+    df = iso.get_fuel_mix(
+        start="Jan 30, 2022",
+        end="Feb 2, 2022",
+        save_to=tmp_path,
+    )
+
+    files = os.listdir(tmp_path)
+
+    assert len(files) == 2
+    assert files == [
+        "NYISO_get_fuel_mix_20220201_20220202.csv",
+        "NYISO_get_fuel_mix_20220130_20220201.csv",
+    ]

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -1,4 +1,6 @@
+import glob
 import io
+import os
 from zipfile import ZipFile
 
 import pandas as pd
@@ -174,3 +176,15 @@ def get_interconnection_queues():
 
 def is_dst_end(date):
     return (date.dst() - (date + pd.DateOffset(1)).dst()).seconds == 3600
+
+
+def load_csv_from_folder(path):
+    """Load csv files from a folder"""
+    all_files = glob.glob(os.path.join(path, "*.csv"))
+
+    dfs = []
+    for f in all_files:
+        df = pd.read_csv(f, parse_dates=True)
+        dfs.append(df)
+
+    return pd.concat(dfs).reset_index(drop=True)

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -178,13 +178,26 @@ def is_dst_end(date):
     return (date.dst() - (date + pd.DateOffset(1)).dst()).seconds == 3600
 
 
-def load_csv_from_folder(path):
-    """Load csv files from a folder"""
+def load_folder(path):
+    """Load a single dataframe for same schema csv files in a folder
+
+    Arguments:
+        path {str} -- path to folder
+
+    Returns:
+        pd.DataFrame -- dataframe of all files
+    """
     all_files = glob.glob(os.path.join(path, "*.csv"))
+    all_files = sorted(all_files)
 
     dfs = []
     for f in all_files:
         df = pd.read_csv(f, parse_dates=True)
         dfs.append(df)
 
-    return pd.concat(dfs).reset_index(drop=True)
+    data = pd.concat(dfs).reset_index(drop=True)
+
+    # todo make sure dates get parsed
+    # todo make sure rows are sorted by time
+
+    return data


### PR DESCRIPTION
This PR adds ability to save intermediate results when fetching data requires multiple requests. 

This can be helpful to
- resume incomplete data fetch
- work with data before query is complete
- recover partial data in event of error

## Usage Example

```python
>>> import gridstatus
>>> iso = gridstatus.CAISO()
>>> iso.get_fuel_mix(start="Jan 1, 2022", end="Jan 14, 2022", save_to="fuel_mix_results/")
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:07<00:00,  1.70it/s]
```

This method call required 13 different request to get data for each day. As a result, in the `fuel_mix_results` folder there are now the following files 

```
fuel_mix_results/
    CAISO_get_fuel_mix_20220101.csv
    CAISO_get_fuel_mix_20220102.csv
    CAISO_get_fuel_mix_20220103.csv
    CAISO_get_fuel_mix_20220104.csv
    CAISO_get_fuel_mix_20220105.csv
    CAISO_get_fuel_mix_20220106.csv
    CAISO_get_fuel_mix_20220107.csv
    CAISO_get_fuel_mix_20220108.csv
    CAISO_get_fuel_mix_20220109.csv
    CAISO_get_fuel_mix_20220110.csv
    CAISO_get_fuel_mix_20220111.csv
    CAISO_get_fuel_mix_20220112.csv
    CAISO_get_fuel_mix_20220113.csv
```

To load all the files back in there is a utility method `gridstatus.load_folder`
```
>>> gridstatus.load_folder("fuel_mix_results")
                           Time  Solar  Wind  Geothermal  Biomass  Biogas  Small Hydro  Coal  Nuclear  Natural Gas  Large Hydro  Batteries  Imports  Other
0     2022-01-08 00:00:00-08:00    -37  4645         894      290     208          200    17     2270         5068         1355        -31     8787      0
1     2022-01-08 00:05:00-08:00    -37  4647         894      290     209          197    17     2269         5225         1285        -59     8751      0
2     2022-01-08 00:10:00-08:00    -37  4588         895      290     209          182    17     2270         5372         1247        -57     8752      0
3     2022-01-08 00:15:00-08:00    -37  4563         896      291     209          175    17     2270         5505         1275        -47     8605      0
4     2022-01-08 00:20:00-08:00    -37  4579         895      292     209          175    17     2269         5538         1275        -29     8446      0
...                         ...    ...   ...         ...      ...     ...          ...   ...      ...          ...          ...        ...      ...    ...
3739  2022-01-01 23:35:00-08:00    -42  1134         879      292     206          194    18     2265         9880         1321        -18     7483      0
3740  2022-01-01 23:40:00-08:00    -43  1108         880      292     206          195    18     2264         9907         1306        -77     7400      0
3741  2022-01-01 23:45:00-08:00    -43  1082         880      294     207          195    18     2265         9983         1297       -130     7384      0
3742  2022-01-01 23:50:00-08:00    -43  1079         879      291     207          194    17     2265         9961         1291        -57     7218      0
3743  2022-01-01 23:55:00-08:00    -43  1047         879      296     207          179    18     2265         9941         1280       -130     7271      0

[3744 rows x 14 columns]
```