### PR TITLE
Error handling on likely missing date range in CAISO LMPS

### DIFF
--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -714,10 +714,14 @@ def _get_oasis(url, usecols=None, verbose=False):
 
     z = ZipFile(io.BytesIO(r.content))
 
-    df = pd.read_csv(
-        z.open(z.namelist()[0]),
-        usecols=usecols,
-    )
+    try:
+        df = pd.read_csv(
+            z.open(z.namelist()[0]),
+            usecols=usecols,
+        )
+    except ValueError:
+        print(f"There was an issue converting the returned zipfile from CAISO OASIS. It could be that\
+        there was no data for the date range selected. Try again with a different date range.")
 
     return df
 


### PR DESCRIPTION
For some methods that hit CAISO OASIS (such as `get_lmp()` ) if a start_date entered does not have valid data, the whole query fails (rather than return the data it can find, or if it can't find any return a useful error message). So I added a simple try/except block for the point in the loop where this is failing (technically fails and returns a `ValueError` on not having the correct columns for `Usecols` within `pd.read_csv()`). There is definitely more robust error handling than what I added that could be here, but wanted to figure out if I was thinking about this correctly first before going hog wild. 

- Example good date range, e.g. October 1st, 2022 start_date:

<img width="1135" alt="image" src="https://user-images.githubusercontent.com/16277874/202940737-bd4ee8ac-a969-420b-ac0e-395ed29af672.png">


- Example bad date range, e.g. Jan 1st, 2017 start_date:

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/16277874/202939477-c3294100-70ea-4752-b168-1e02857d2dad.png">


I haven't exhausted that this could be a data volume issue rather than a valid date range issue, since Jan 2017 doesn't seem like it would be that far back for a hub price, but I did successfully pull a few years worth and the loader bar appears each time, so it seems it can handle the multi-year pull just fine (but not when there isn't data for the start_date)

Let me know if this makes sense. Kind of an excuse to make my first contribution!
