### PR TITLE
ERCOT: get_load supports more historical data

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -101,6 +101,7 @@ class Ercot(ISOBase):
         else:
             raise NotSupported()
 
+    @support_date_range("1D")
     def get_load(self, date, verbose=False):
         if date == "latest":
             d = self._get_load_json("currentDay").iloc[-1]

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -86,7 +86,7 @@ class Ercot(ISOBase):
             df = pd.DataFrame(r["currentDay"]["data"].values())
             df = df.dropna(subset=["actualSolar"])
 
-            df = self._handle_data(
+            df = self._handle_json_data(
                 df,
                 {"actualSolar": "Solar", "actualWind": "Wind"},
             )
@@ -122,7 +122,7 @@ class Ercot(ISOBase):
         r = self._get_json(url)
         df = pd.DataFrame(r[when]["data"])
         df = df.dropna(subset=["systemLoad"])
-        df = self._handle_data(df, {"systemLoad": "Load"})
+        df = self._handle_json_data(df, {"systemLoad": "Load"})
         return df
 
     def _get_supply(self, date, verbose=False):
@@ -441,7 +441,7 @@ class Ercot(ISOBase):
         url = f"https://www.ercot.com/misdownload/servlets/mirDownload?doclookupId={doc[1]}"
         return url, doc[0]
 
-    def _handle_data(self, df, columns):
+    def _handle_json_data(self, df, columns):
         df["Time"] = (
             pd.to_datetime(df["epoch"], unit="ms")
             .dt.tz_localize("UTC")

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -101,17 +101,17 @@ class Ercot(ISOBase):
 
     def get_load(self, date, verbose=False):
         if date == "latest":
-            d = self._get_load("currentDay").iloc[-1]
+            d = self._get_load_json("currentDay").iloc[-1]
 
             return {"time": d["Time"], "load": d["Load"]}
 
         elif utils.is_today(date):
-            return self._get_load("currentDay")
+            return self._get_load_json("currentDay")
 
         else:
             raise NotSupported()
 
-    def _get_load(self, when):
+    def _get_load_json(self, when):
         """Returns load for currentDay or previousDay"""
         # todo switch to https://www.ercot.com/content/cdr/html/20220810_actual_loads_of_forecast_zones.html
         # says supports last 5 days, appears to support last two weeks

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -48,3 +48,30 @@ def test_ercot_get_as_prices():
     assert df.shape[0] >= 0
     assert df.columns.tolist() == as_cols
     assert df["Time"].unique()[0].date() == date
+
+
+def test_ercot_get_load_today():
+    cols = [
+        "Time",
+        "Load",
+    ]
+    iso = gridstatus.Ercot()
+    today = pd.Timestamp.now().date()
+    df = iso.get_load(today)
+    assert df.shape[0] >= 0
+    assert df.columns.tolist() == cols
+    assert df["Time"].unique()[0].date() == today
+
+
+def test_ercot_get_load_3_days_ago():
+    cols = [
+        "Time",
+        "Load",
+    ]
+    iso = gridstatus.Ercot()
+    today = pd.Timestamp.now().date()
+    three_days_ago = today - pd.Timedelta(days=3)
+    df = iso.get_load(three_days_ago)
+    assert df.shape[0] >= 0
+    assert df.columns.tolist() == cols
+    assert df["Time"].unique()[0].date() == three_days_ago

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -37,7 +37,7 @@ def test_ercot_get_as_prices():
 
     # today
     iso = gridstatus.Ercot()
-    today = pd.Timestamp.now().date()
+    today = pd.Timestamp.now(tz=iso.default_timezone).date()
     df = iso.get_as_prices(today)
     assert df.shape[0] >= 0
     assert df.columns.tolist() == as_cols
@@ -56,7 +56,7 @@ def test_ercot_get_load_today():
         "Load",
     ]
     iso = gridstatus.Ercot()
-    today = pd.Timestamp.now().date()
+    today = pd.Timestamp.now(tz=iso.default_timezone).date()
     df = iso.get_load(today)
     assert df.shape[0] >= 0
     assert df.columns.tolist() == cols
@@ -69,7 +69,7 @@ def test_ercot_get_load_3_days_ago():
         "Load",
     ]
     iso = gridstatus.Ercot()
-    today = pd.Timestamp.now().date()
+    today = pd.Timestamp.now(tz=iso.default_timezone).date()
     three_days_ago = today - pd.Timedelta(days=3)
     df = iso.get_load(three_days_ago)
     assert df.shape[0] >= 0

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -139,6 +139,14 @@ def is_today(date, tz=None):
     return _handle_date(date, tz=tz).date() == pd.Timestamp.now(tz=tz).date()
 
 
+def is_within_last_days(date, days, tz=None):
+    """Returns whether date is within N days"""
+    now = pd.Timestamp.now(tz=tz).date()
+    date_value = _handle_date(date, tz=tz).date()
+    period_start = (now - pd.DateOffset(days=days)).date()
+    return date_value <= now and date_value >= period_start
+
+
 def format_interconnection_df(queue, rename, extra=None, missing=None):
     """Format interconnection queue data"""
     assert set(rename.keys()).issubset(queue.columns), set(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "tqdm >= 4.64.1",
     "openpyxl >= 3.0.10",
     "tabula-py >= 2.5.1",
+    "lxml >= 4.9.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
For ERCOT, adds support for load data from https://www.ercot.com/content/cdr/html/actual_loads_of_forecast_zones.html as mentioned in the TODO comments.

Highlights:

* Still pulls from the JSON endpoint when `date == 'currentDay'`
* Otherwise, pulls from HTML endpoint, up to 14 days ago
* Requires `lxml` due to `pd.read_html`