### PR TITLE
ERCOT: get_load uses todays-outlook.json

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -231,13 +231,15 @@ class Ercot(ISOBase):
         df = self._handle_html_data(df, {"TOTAL": "Load"})
         return df
 
-    def _get_supply(self, date, verbose=False):
+    def _get_todays_outlook_non_forecast(self, date, verbose=False):
         """Returns most recent data point for supply in MW
 
         Updates every 5 minutes
         """
         assert date == "today", "Only today's data is supported"
         url = self.BASE + "/todays-outlook.json"
+        if verbose:
+            print(f"Fetching {url}", file=sys.stderr)
         r = self._get_json(url)
 
         date = pd.to_datetime(r["lastUpdated"][:10], format="%Y-%m-%d")
@@ -254,10 +256,6 @@ class Ercot(ISOBase):
         ).dt.tz_localize(self.default_timezone, ambiguous="infer")
 
         data = data[data["forecast"] == 0]  # only keep non forecast rows
-
-        data = data[["Time", "capacity"]].rename(
-            columns={"capacity": "Supply"},
-        )
 
         return data
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -196,12 +196,13 @@ class Ercot(ISOBase):
     @support_date_range("1D")
     def get_load(self, date, verbose=False):
         if date == "latest":
-            d = self._get_load_json("currentDay").iloc[-1]
-
-            return {"time": d["Time"], "load": d["Load"]}
+            today_load = self.get_load("today", verbose=verbose)
+            return today_load.iloc[-1].to_dict()
 
         elif utils.is_today(date):
-            return self._get_load_json("currentDay")
+            df = self._get_todays_outlook_non_forecast(date, verbose=verbose)
+            df = df.rename(columns={"demand": "Load"})
+            return df[["Time", "Load"]]
 
         elif utils.is_within_last_days(date, self.LOAD_HISTORICAL_MAX_DAYS):
             return self._get_load_html(date)

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -236,7 +236,10 @@ class Ercot(ISOBase):
 
         Updates every 5 minutes
         """
-        assert date == "today", "Only today's data is supported"
+        assert date == "latest" or utils.is_today(
+            date,
+            self.default_timezone,
+        ), "Only today's data is supported"
         url = self.BASE + "/todays-outlook.json"
         if verbose:
             print(f"Fetching {url}", file=sys.stderr)

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -197,7 +197,8 @@ class Ercot(ISOBase):
     def get_load(self, date, verbose=False):
         if date == "latest":
             today_load = self.get_load("today", verbose=verbose)
-            return today_load.iloc[-1].to_dict()
+            latest = today_load.iloc[-1]
+            return {"load": latest["Load"], "time": latest["Time"]}
 
         elif utils.is_today(date):
             df = self._get_todays_outlook_non_forecast(date, verbose=verbose)

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -76,14 +76,14 @@ def test_ercot_get_load_today():
 
 def test_ercot_get_load_latest():
     expected_keys = {
-        "Time",
-        "Load",
+        "time",
+        "load",
     }
     iso = gridstatus.Ercot()
     today = pd.Timestamp.now(tz=iso.default_timezone).date()
     load = iso.get_load("latest")
     assert load.keys() == expected_keys
-    assert load["Time"].date() == today
+    assert load["time"].date() == today
 
 
 def test_ercot_get_load_3_days_ago():

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -74,6 +74,18 @@ def test_ercot_get_load_today():
     assert df["Time"].unique()[0].date() == today
 
 
+def test_ercot_get_load_latest():
+    expected_keys = {
+        "Time",
+        "Load",
+    }
+    iso = gridstatus.Ercot()
+    today = pd.Timestamp.now(tz=iso.default_timezone).date()
+    load = iso.get_load("latest")
+    assert load.keys() == expected_keys
+    assert load["Time"].date() == today
+
+
 def test_ercot_get_load_3_days_ago():
     cols = [
         "Time",


### PR DESCRIPTION
Addresses #99 which pulls from https://www.ercot.com/api/1/services/read/dashboards/todays-outlook.json for today and latest.

The numbers differ (less than 3%) from the old endpoint, but I confirmed it matches the Demand trend on the associated dashboard page - https://www.ercot.com/gridmktinfo/dashboards/supplyanddemand:

```python
iso = gridstatus.Ercot()
today = iso._get_load_json("currentDay")
today2 = iso._get_todays_outlook_non_forecast("today").rename(columns={"demand": "Load"})
df = pd.merge(today, today2, suffixes=("_control", "_experiment"), on="Time")
df["Load_delta"] = df["Load_control"] - df["Load_experiment"]
df["Load_delta_pct"] = df["Load_delta"] / df["Load_control"] * 100.0
df = df[["Time", "Load_control", "Load_experiment", "Load_delta", "Load_delta_pct"]]
print(df.sort_values(by="Time").reset_index(drop=True).to_string())
```
```
                        Time  Load_control  Load_experiment  Load_delta  Load_delta_pct
0  2022-12-27 01:00:00-06:00      46493.58            46447       46.58        0.100186
1  2022-12-27 02:00:00-06:00      46660.27            47015     -354.73       -0.760240
2  2022-12-27 03:00:00-06:00      47486.36            47957     -470.64       -0.991106
3  2022-12-27 04:00:00-06:00      48385.85            48816     -430.15       -0.889000
4  2022-12-27 05:00:00-06:00      50027.51            51025     -997.49       -1.993883
5  2022-12-27 06:00:00-06:00      52589.68            53980    -1390.32       -2.643713
6  2022-12-27 07:00:00-06:00      55716.44            57158    -1441.56       -2.587315
7  2022-12-27 08:00:00-06:00      57876.19            58455     -578.81       -1.000083
8  2022-12-27 09:00:00-06:00      57562.39            56452     1110.39        1.929020
9  2022-12-27 10:00:00-06:00      55368.85            53768     1600.85        2.891247
10 2022-12-27 11:00:00-06:00      52569.46            51029     1540.46        2.930333
11 2022-12-27 12:00:00-06:00      49921.23            48605     1316.23        2.636614
12 2022-12-27 13:00:00-06:00      47462.76            46323     1139.76        2.401377
13 2022-12-27 14:00:00-06:00      45519.76            44658      861.76        1.893156
14 2022-12-27 15:00:00-06:00      44264.55            43744      520.55        1.175997
```