### PR TITLE
Add ruff for linting, remove flake8, remove isort

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,8 +22,3 @@ jobs:
       - name: Run lint test
         run: make lint
       - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,11 +1,5 @@
 name: Lint Check
-on:
-  pull_request:
-    types: [opened, synchronize]
-  push:
-    branches:
-      - main
-
+on: [pull_request]
 jobs:
   lint_test:
     name: 3.11 lint check
@@ -19,6 +13,5 @@ jobs:
       - name: Install package with dev deps
         run: |
           python -m pip install -e ".[dev]"
-      - name: Run lint test
+      - name: Run lint check
         run: make lint
-      - name: Lint with flake8

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,7 @@
 name: Lint Check
 on: [pull_request]
 jobs:
-  lint_test:
+  lint_check:
     name: 3.11 lint check
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,13 +21,14 @@ repos:
     rev: v0.10.1
     hooks:
       - id: validate-pyproject
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.202
-    hooks:
-      - id: ruff
   - repo: https://github.com/python/black
     rev: 22.12.0
     hooks:
       - id: black
+        args: [--target-version=py311 --line-length 88]
         additional_dependencies: [".[jupyter]"]
         types_or: [python, jupyter]
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.202
+    hooks:
+      - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,9 @@ repos:
     rev: 22.12.0
     hooks:
       - id: black
-        args: [--target-version=py311 --line-length 88]
+        args:
+          - --target-version=py311
+          - --line-length=88
         additional_dependencies: [".[jupyter]"]
         types_or: [python, jupyter]
   - repo: https://github.com/charliermarsh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
     hooks:
       - id: add-trailing-comma
         name: Add trailing comma
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.10.1
+    hooks:
+      - id: validate-pyproject
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
@@ -32,7 +36,3 @@ repos:
     rev: v0.0.202
     hooks:
       - id: ruff
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.10.1
-    hooks:
-      - id: validate-pyproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,10 +21,6 @@ repos:
     rev: v0.10.1
     hooks:
       - id: validate-pyproject
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
   - repo: https://github.com/python/black
     rev: 22.12.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
+      - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/MarcoGorelli/absolufy-imports
@@ -27,3 +28,11 @@ repos:
         args: [--target-version=py311]
         additional_dependencies: [".[jupyter]"]
         types_or: [python, jupyter]
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.202
+    hooks:
+      - id: ruff
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.10.1
+    hooks:
+      - id: validate-pyproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
     rev: 22.12.0
     hooks:
       - id: black
-        args: [--target-version=py311]
         additional_dependencies: [".[jupyter]"]
         types_or: [python, jupyter]
   - repo: https://github.com/charliermarsh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,13 +21,13 @@ repos:
     rev: v0.10.1
     hooks:
       - id: validate-pyproject
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.202
+    hooks:
+      - id: ruff
   - repo: https://github.com/python/black
     rev: 22.12.0
     hooks:
       - id: black
         additional_dependencies: [".[jupyter]"]
         types_or: [python, jupyter]
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.202
-    hooks:
-      - id: ruff

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ installdeps-docs:
 lint:
 	isort --check-only gridstatus/
 	black gridstatus/ -t py311 --check
+	ruff gridstatus/
 
 .PHONY: lint-fix
 lint-fix:
 	black gridstatus/ -t py311
 	isort gridstatus/
+	ruff gridstatus/ --fix
 
 .PHONY: upgradepip
 upgradepip:

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ installdeps-docs:
 
 .PHONY: lint
 lint:
-	black gridstatus/ -t py311 --check
 	ruff gridstatus/
+	black gridstatus/ --check
 
 .PHONY: lint-fix
 lint-fix:
-	black gridstatus/ -t py311
 	ruff gridstatus/ --fix
+	black gridstatus/
 
 .PHONY: upgradepip
 upgradepip:

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,11 @@ installdeps-docs:
 
 .PHONY: lint
 lint:
-	isort --check-only gridstatus/
 	black gridstatus/ -t py311 --check
 	ruff gridstatus/
 
 .PHONY: lint-fix
 lint-fix:
-	isort gridstatus/
 	black gridstatus/ -t py311
 	ruff gridstatus/ --fix
 

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ lint:
 
 .PHONY: lint-fix
 lint-fix:
-	black gridstatus/ -t py311
 	isort gridstatus/
+	black gridstatus/ -t py311
 	ruff gridstatus/ --fix
 
 .PHONY: upgradepip

--- a/docs/Examples/spp/LMP Data.ipynb
+++ b/docs/Examples/spp/LMP Data.ipynb
@@ -196,10 +196,7 @@
     }
    ],
    "source": [
-    "df = iso.get_lmp(\n",
-    "    date=\"latest\",\n",
-    "    market=\"REAL_TIME_5_MIN\"\n",
-    ")\n",
+    "df = iso.get_lmp(date=\"latest\", market=\"REAL_TIME_5_MIN\")\n",
     "df"
    ]
   },
@@ -333,9 +330,7 @@
    ],
    "source": [
     "df = iso.get_lmp(\n",
-    "    date=\"latest\",\n",
-    "    market=\"REAL_TIME_5_MIN\",\n",
-    "    location_type=\"SETTLEMENT_LOCATION\"\n",
+    "    date=\"latest\", market=\"REAL_TIME_5_MIN\", location_type=\"SETTLEMENT_LOCATION\"\n",
     ")\n",
     "df.head(5)"
    ]
@@ -500,11 +495,7 @@
     }
    ],
    "source": [
-    "df = iso.get_lmp(\n",
-    "    date=\"latest\",\n",
-    "    market=\"REAL_TIME_5_MIN\",\n",
-    "    location_type=\"Interface\"\n",
-    ")\n",
+    "df = iso.get_lmp(date=\"latest\", market=\"REAL_TIME_5_MIN\", location_type=\"Interface\")\n",
     "df.head(5)"
    ]
   },
@@ -637,11 +628,7 @@
     }
    ],
    "source": [
-    "df = iso.get_lmp(\n",
-    "    date=\"today\",\n",
-    "    market=\"REAL_TIME_5_MIN\",\n",
-    "    location_type=\"Interface\"\n",
-    ")\n",
+    "df = iso.get_lmp(date=\"today\", market=\"REAL_TIME_5_MIN\", location_type=\"Interface\")\n",
     "df.head(5)"
    ]
   },
@@ -776,11 +763,7 @@
     }
    ],
    "source": [
-    "df = iso.get_lmp(\n",
-    "    date=\"today\",\n",
-    "    market=\"DAY_AHEAD_HOURLY\",\n",
-    "    location_type=\"Hub\"\n",
-    ")\n",
+    "df = iso.get_lmp(date=\"today\", market=\"DAY_AHEAD_HOURLY\", location_type=\"Hub\")\n",
     "df.head(5)"
    ]
   },
@@ -915,11 +898,7 @@
     }
    ],
    "source": [
-    "df = iso.get_lmp(\n",
-    "    date=\"today\",\n",
-    "    market=\"DAY_AHEAD_HOURLY\",\n",
-    "    location_type=\"Interface\"\n",
-    ")\n",
+    "df = iso.get_lmp(date=\"today\", market=\"DAY_AHEAD_HOURLY\", location_type=\"Interface\")\n",
     "df.head(5)"
    ]
   }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ extensions = [
     "sphinx-favicon",
     "sphinx.ext.inheritance_diagram",
     "sphinxext.opengraph",
+    "sphinx.ext.napoleon",
 ]
 
 templates_path = ["_templates"]

--- a/docs/update_docs.py
+++ b/docs/update_docs.py
@@ -1,4 +1,3 @@
-import gridstatus
 from gridstatus.utils import make_availability_table, make_lmp_availability_table
 
 

--- a/gridstatus/__init__.py
+++ b/gridstatus/__init__.py
@@ -1,20 +1,11 @@
-from gridstatus.version import __version__
-
 from gridstatus.utils import (
     list_isos,
     get_iso,
-    make_availability_table,
     get_interconnection_queues,
 )
-from gridstatus import tests
-import gridstatus.base
-import gridstatus.decorators
 
 from gridstatus.base import Markets, NotSupported
 
-import gridstatus.utils
-
-import gridstatus.viz
 
 from gridstatus.utils import load_folder
 

--- a/gridstatus/__init__.py
+++ b/gridstatus/__init__.py
@@ -1,21 +1,17 @@
-from gridstatus.utils import (
-    list_isos,
-    get_iso,
-    get_interconnection_queues,
-)
-
 from gridstatus.base import Markets, NotSupported
-
-
-from gridstatus.utils import load_folder
-
-from gridstatus.nyiso import NYISO
 from gridstatus.caiso import CAISO
 from gridstatus.ercot import Ercot
 from gridstatus.isone import ISONE
 from gridstatus.miso import MISO
-from gridstatus.spp import SPP
+from gridstatus.nyiso import NYISO
 from gridstatus.pjm import PJM
+from gridstatus.spp import SPP
+from gridstatus.utils import (
+    get_interconnection_queues,
+    get_iso,
+    list_isos,
+    load_folder,
+)
 
 all_isos = [NYISO, CAISO, Ercot, ISONE, MISO, SPP, PJM]
 

--- a/gridstatus/__init__.py
+++ b/gridstatus/__init__.py
@@ -1,17 +1,30 @@
+from gridstatus.version import __version__
+
+from gridstatus.utils import (
+    list_isos,
+    get_iso,
+    make_availability_table,
+    get_interconnection_queues,
+)
+from gridstatus import tests
+import gridstatus.base
+import gridstatus.decorators
+
 from gridstatus.base import Markets, NotSupported
+
+import gridstatus.utils
+
+import gridstatus.viz
+
+from gridstatus.utils import load_folder
+
+from gridstatus.nyiso import NYISO
 from gridstatus.caiso import CAISO
 from gridstatus.ercot import Ercot
 from gridstatus.isone import ISONE
 from gridstatus.miso import MISO
-from gridstatus.nyiso import NYISO
-from gridstatus.pjm import PJM
 from gridstatus.spp import SPP
-from gridstatus.utils import (
-    get_interconnection_queues,
-    get_iso,
-    list_isos,
-    load_folder,
-)
+from gridstatus.pjm import PJM
 
 all_isos = [NYISO, CAISO, Ercot, ISONE, MISO, SPP, PJM]
 

--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -81,11 +81,14 @@ class ISOBase:
         """Get fuel mix in 5 minute intervals for a provided day
 
         Arguments:
-            date (datetime or str): "latest", "today", or an object that can be parsed as a datetime for the day to return data.
+            date (datetime or str): "latest", "today", or an object that can be parsed
+                as a datetime for the day to return data.
 
-            start (datetime or str): start of date range to return. alias for `date` parameter. Only specify one of `date` or `start`.
+            start (datetime or str): start of date range to return. alias for `date` parameter.
+                Only specify one of `date` or `start`.
 
-            end (datetime or str): "today" or an object that can be parsed as a datetime for the day to return data. Only used if requesting a range of dates.
+            end (datetime or str): "today" or an object that can be parsed as a datetime for the
+                day to return data. Only used if requesting a range of dates.
 
             verbose (bool): print verbose output. Defaults to False.
 

--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -82,22 +82,22 @@ class ISOBase:
 
         Arguments:
             date (datetime or str): "latest", "today", or an object
-                that can be parsed as a datetime for the day to return data.
+            that can be parsed as a datetime for the day to return data.
 
             start (datetime or str): start of date range to return.
-                alias for `date` parameter.
-                Only specify one of `date` or `start`.
+            alias for `date` parameter.
+            Only specify one of `date` or `start`.
 
             end (datetime or str): "today" or an object that can be parsed
-                as a datetime for the day to return data.
-                Only used if requesting a range of dates.
+            as a datetime for the day to return data.
+            Only used if requesting a range of dates.
 
             verbose (bool): print verbose output. Defaults to False.
 
 
         Returns:
             df (pd.Dataframe): dataframe with columns:
-                Time and columns for each fuel type
+            Time and columns for each fuel type
         """
         raise NotImplementedError()
 

--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -81,23 +81,23 @@ class ISOBase:
         """Get fuel mix in 5 minute intervals for a provided day
 
         Arguments:
-            date (datetime or str): "latest", "today", or an object
-            that can be parsed as a datetime for the day to return data.
+            date (datetime.date, str): "latest", "today", or an object
+                that can be parsed as a datetime for the day to return data.
 
-            start (datetime or str): start of date range to return.
-            alias for `date` parameter.
-            Only specify one of `date` or `start`.
+            start (datetime.date, str): start of date range to return.
+                alias for `date` parameter.
+                Only specify one of `date` or `start`.
 
-            end (datetime or str): "today" or an object that can be parsed
-            as a datetime for the day to return data.
-            Only used if requesting a range of dates.
+            end (datetime.date, str): "today" or an object that can be parsed
+                as a datetime for the day to return data.
+                Only used if requesting a range of dates.
 
-            verbose (bool): print verbose output. Defaults to False.
+            verbose (bool, optional): print verbose output. Defaults to False.
 
 
         Returns:
-            df (pd.Dataframe): dataframe with columns:
-            Time and columns for each fuel type
+            pandas.DataFrame: A DataFrame with columns for Time and columns \
+                for each fuel type
         """
         raise NotImplementedError()
 

--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -78,27 +78,6 @@ class ISOBase:
         raise NotImplementedError()
 
     def get_fuel_mix(self, date, end=None, verbose=False):
-        """Get fuel mix in 5 minute intervals for a provided day
-
-        Arguments:
-            date (datetime.date, str): "latest", "today", or an object
-                that can be parsed as a datetime for the day to return data.
-
-            start (datetime.date, str): start of date range to return.
-                alias for `date` parameter.
-                Only specify one of `date` or `start`.
-
-            end (datetime.date, str): "today" or an object that can be parsed
-                as a datetime for the day to return data.
-                Only used if requesting a range of dates.
-
-            verbose (bool, optional): print verbose output. Defaults to False.
-
-
-        Returns:
-            pandas.DataFrame: A DataFrame with columns for Time and columns \
-                for each fuel type
-        """
         raise NotImplementedError()
 
     def get_load(self, date, end=None, verbose=False):

--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -81,20 +81,23 @@ class ISOBase:
         """Get fuel mix in 5 minute intervals for a provided day
 
         Arguments:
-            date (datetime or str): "latest", "today", or an object that can be parsed
-                as a datetime for the day to return data.
+            date (datetime or str): "latest", "today", or an object
+                that can be parsed as a datetime for the day to return data.
 
-            start (datetime or str): start of date range to return. alias for `date` parameter.
+            start (datetime or str): start of date range to return.
+                alias for `date` parameter.
                 Only specify one of `date` or `start`.
 
-            end (datetime or str): "today" or an object that can be parsed as a datetime for the
-                day to return data. Only used if requesting a range of dates.
+            end (datetime or str): "today" or an object that can be parsed
+                as a datetime for the day to return data.
+                Only used if requesting a range of dates.
 
             verbose (bool): print verbose output. Defaults to False.
 
 
         Returns:
-            pd.Dataframe: dataframe with columns: Time and columns for each fuel type
+            df (pd.Dataframe): dataframe with columns:
+                Time and columns for each fuel type
         """
         raise NotImplementedError()
 

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -68,7 +68,7 @@ class CAISO(ISOBase):
 
     @support_date_range(frequency="1D")
     def get_fuel_mix(self, date, start=None, end=None, verbose=False):
-        """Get fuel mix in 5 minute intervals for a provided day CAISO
+        """Get fuel mix in 5 minute intervals for a provided day
 
         Arguments:
             date (datetime.date, str): "latest", "today", or an object
@@ -86,7 +86,7 @@ class CAISO(ISOBase):
 
         Returns:
             pandas.DataFrame: A DataFrame with columns - 'Time' and columns
-            for each fuel type.
+                for each fuel type.
         """
         if date == "latest":
             mix = self.get_fuel_mix("today", verbose=verbose)

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -7,7 +7,6 @@ import pandas as pd
 import requests
 import tabula
 
-import gridstatus
 from gridstatus import utils
 from gridstatus.base import FuelMix, GridStatus, ISOBase, Markets, NotSupported
 from gridstatus.decorators import support_date_range
@@ -560,7 +559,7 @@ class CAISO(ISOBase):
         with io.StringIO() as buf, redirect_stderr(buf):
             try:
                 tables = tabula.read_pdf(pdf, pages="all")
-            except:
+            except Exception:
                 print(buf.getvalue())
                 raise RuntimeError("Problem Reading PDF")
 
@@ -854,7 +853,6 @@ if __name__ == "__main__":
 
     # check if any files are missing
     import glob
-    import os
 
     files = glob.glob("caiso_curtailment/*.csv")
     dates = (

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -71,16 +71,22 @@ class CAISO(ISOBase):
         """Get fuel mix in 5 minute intervals for a provided day
 
         Arguments:
-            date (datetime or str): "latest", "today", or an object that can be parsed as a datetime for the day to return data.
+            date (datetime or str): "latest", "today", or an object
+                that can be parsed as a datetime for the day to return data.
 
-            start (datetime or str): start of date range to return. alias for `date` parameter. Only specify one of `date` or `start`.
+            start (datetime or str): start of date range to return.
+                alias for `date` parameter.
+                Only specify one of `date` or `start`.
 
-            end (datetime or str): "today" or an object that can be parsed as a datetime for the day to return data. Only used if requesting a range of dates.
+            end (datetime or str): "today" or an object that can be parsed
+                as a datetime for the day to return data.
+                Only used if requesting a range of dates.
 
             verbose (bool): print verbose output. Defaults to False.
 
         Returns:
-            pd.Dataframe: dataframe with columns: Time and columns for each fuel type
+            df (pd.Dataframe): dataframe with columns: Time and columns
+                for each fuel type
         """
         if date == "latest":
             mix = self.get_fuel_mix("today", verbose=verbose)
@@ -141,8 +147,10 @@ class CAISO(ISOBase):
         """Returns load forecast for a previous date in 1 hour intervals
 
         Arguments:
-            date(datetime, pd.Timestamp, or str): day to return. if string, format should be YYYYMMDD e.g 20200623
-            sleep(int): number of seconds to sleep before returning to avoid hitting rate limit in regular usage. Defaults to 5 seconds.
+            date(datetime, pd.Timestamp, or str): day to return.
+                If string, format should be YYYYMMDD e.g 20200623
+            sleep(int): number of seconds to sleep before returning to avoid
+                hitting rate limit in regular usage. Defaults to 5 seconds.
 
         """
 
@@ -174,7 +182,7 @@ class CAISO(ISOBase):
         return df
 
     def get_pnodes(self):
-        url = "http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=ATL_PNODE_MAP&version=1&startdatetime=20220801T07:00-0000&enddatetime=20220802T07:00-0000&pnode_id=ALL"
+        url = "http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=ATL_PNODE_MAP&version=1&startdatetime=20220801T07:00-0000&enddatetime=20220802T07:00-0000&pnode_id=ALL"  # noqa
         df = pd.read_csv(
             url,
             compression="zip",
@@ -204,10 +212,14 @@ class CAISO(ISOBase):
 
             market: market to return from. supports:
 
-            locations(list): list of locations to get data from. If no locations are provided, defaults to NP15, SP15, and ZP26, which are the trading hub locations.
-            For a list of locations, call CAISO.get_pnodes()
+            locations(list): list of locations to get data from.
+                If no locations are provided, defaults to NP15, SP15, and ZP26,
+                which are the trading hub locations.
+                For a list of locations, call CAISO.get_pnodes()
 
-            sleep(int): number of seconds to sleep before returning to avoid hitting rate limit in regular usage. Defaults to 5 seconds.
+            sleep(int): number of seconds to sleep before returning to
+                avoid hitting rate limit in regular usage.
+                Defaults to 5 seconds.
 
         Returns
             dataframe of pricing data
@@ -241,7 +253,7 @@ class CAISO(ISOBase):
             raise RuntimeError("LMP Market is not supported")
 
         nodes_str = ",".join(locations)
-        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname={query_name}&version={version}&startdatetime={start}&enddatetime={end}&market_run_id={market_run_id}&node={nodes_str}"
+        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname={query_name}&version={version}&startdatetime={start}&enddatetime={end}&market_run_id={market_run_id}&node={nodes_str}"  # noqa
 
         df = _get_oasis(
             url,
@@ -333,9 +345,12 @@ class CAISO(ISOBase):
         Arguments:
             date: date to return data
 
-            end: last date of range to return data. if None, returns only date. Defaults to None.
+            end: last date of range to return data. If None, returns only date.
+                Defaults to None.
 
-            fuel_region_id(str, or list): single fuel region id or list of fuel region ids to return data for. Defaults to ALL, which returns all fuel regions.
+            fuel_region_id(str, or list): single fuel region id or list of fuel
+                region ids to return data for. Defaults to ALL, which returns
+                all fuel regions.
 
         Returns:
             dataframe of gas prices
@@ -346,7 +361,7 @@ class CAISO(ISOBase):
         if isinstance(fuel_region_id, list):
             fuel_region_id = ",".join(fuel_region_id)
 
-        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=PRC_FUEL&version=1&FUEL_REGION_ID={fuel_region_id}&startdatetime={start}&enddatetime={end}"
+        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=PRC_FUEL&version=1&FUEL_REGION_ID={fuel_region_id}&startdatetime={start}&enddatetime={end}"  # noqa
 
         df = _get_oasis(
             url,
@@ -385,12 +400,13 @@ class CAISO(ISOBase):
 
         Arguments:
             date: date to return data
-            end: last date of range to return data. if None, returns only date. Defaults to None.
+            end: last date of range to return data.
+                If None, returns only date. Defaults to None.
         """
 
         start, end = _caiso_handle_start_end(date, end)
 
-        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=PRC_GHG_ALLOWANCE&version=1&startdatetime={start}&enddatetime={end}"
+        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=PRC_GHG_ALLOWANCE&version=1&startdatetime={start}&enddatetime={end}"  # noqa
 
         df = _get_oasis(
             url,
@@ -523,7 +539,8 @@ class CAISO(ISOBase):
 
         Arguments:
             date: date to return data
-            end: last date of range to return data. if None, returns only date. Defaults to None.
+            end: last date of range to return data.
+                If None, returns only date. Defaults to None.
             verbose: print out url being fetched. Defaults to False.
 
         Returns:
@@ -544,14 +561,15 @@ class CAISO(ISOBase):
         if date_strs[0] == "Dec02_2021":
             date_strs = ["02dec_2020"]
         if date_strs[0] == "Dec02_2020":
-            # this correct, so make sure we don't try the other file since 2021 is published wrong
+            # this correct, so make sure we don't try the
+            # other file since 2021 is published wrong
             date_strs = ["Dec02_2020"]
 
         # todo handle not always just 4th pge
 
         pdf = None
         for date_str in date_strs:
-            f = f"http://www.caiso.com/Documents/Wind_SolarReal-TimeDispatchCurtailmentReport{date_str}.pdf"
+            f = f"http://www.caiso.com/Documents/Wind_SolarReal-TimeDispatchCurtailmentReport{date_str}.pdf"  # noqa
             if verbose:
                 print("Fetching URL: ", f)
             r = requests.get(f)
@@ -581,8 +599,10 @@ class CAISO(ISOBase):
         elif len(tables) == 1:
             df = tables[0]
         else:
-            # this is case where there was a continuation of the curtailment table
-            # on a second page. there is no header, make parsed header of extra table the first row
+            # this is case where there was a continuation of the
+            # curtailment table
+            # on a second page. there is no header,
+            # make parsed header of extra table the first row
 
             def _handle_extra_table(extra_table):
                 extra_table = pd.concat(
@@ -649,7 +669,8 @@ class CAISO(ISOBase):
 
         Arguments:
             date: date to return data
-            end: last date of range to return data. if None, returns only date. Defaults to None.
+            end: last date of range to return data.
+                If None, returns only date. Defaults to None.
             verbose: print out url being fetched. Defaults to False.
 
         Returns:
@@ -658,7 +679,7 @@ class CAISO(ISOBase):
 
         start, end = _caiso_handle_start_end(date, end)
 
-        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=PRC_AS&version=12&startdatetime={start}&enddatetime={end}&market_run_id=DAM&anc_type=ALL&anc_region=ALL"
+        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=PRC_AS&version=12&startdatetime={start}&enddatetime={end}&market_run_id=DAM&anc_type=ALL&anc_region=ALL"  # noqa
 
         df = _get_oasis(url=url, verbose=verbose, sleep=sleep).rename(
             columns={
@@ -703,7 +724,8 @@ class CAISO(ISOBase):
 
         Arguments:
             date: date to return data
-            end: last date of range to return data. if None, returns only date. Defaults to None.
+            end: last date of range to return data.
+                If None, returns only date. Defaults to None.
             market: DAM or RTM. Defaults to DAM.
 
         Returns:
@@ -713,7 +735,7 @@ class CAISO(ISOBase):
 
         start, end = _caiso_handle_start_end(date, end)
 
-        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=AS_RESULTS&version=1&startdatetime={start}&enddatetime={end}&market_run_id={market}&anc_type=ALL&anc_region=ALL"
+        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=AS_RESULTS&version=1&startdatetime={start}&enddatetime={end}&market_run_id={market}&anc_type=ALL&anc_region=ALL"  # noqa
 
         df = _get_oasis(url=url, verbose=verbose, sleep=sleep).rename(
             columns={

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -72,21 +72,21 @@ class CAISO(ISOBase):
 
         Arguments:
             date (datetime or str): "latest", "today", or an object
-                that can be parsed as a datetime for the day to return data.
+            that can be parsed as a datetime for the day to return data.
 
             start (datetime or str): start of date range to return.
-                alias for `date` parameter.
-                Only specify one of `date` or `start`.
+            alias for `date` parameter.
+            Only specify one of `date` or `start`.
 
             end (datetime or str): "today" or an object that can be parsed
-                as a datetime for the day to return data.
-                Only used if requesting a range of dates.
+            as a datetime for the day to return data.
+            Only used if requesting a range of dates.
 
             verbose (bool): print verbose output. Defaults to False.
 
         Returns:
             df (pd.Dataframe): dataframe with columns: Time and columns
-                for each fuel type
+            for each fuel type
         """
         if date == "latest":
             mix = self.get_fuel_mix("today", verbose=verbose)
@@ -148,9 +148,10 @@ class CAISO(ISOBase):
 
         Arguments:
             date(datetime, pd.Timestamp, or str): day to return.
-                If string, format should be YYYYMMDD e.g 20200623
+            If string, format should be YYYYMMDD e.g 20200623
+
             sleep(int): number of seconds to sleep before returning to avoid
-                hitting rate limit in regular usage. Defaults to 5 seconds.
+            hitting rate limit in regular usage. Defaults to 5 seconds.
 
         """
 
@@ -213,13 +214,13 @@ class CAISO(ISOBase):
             market: market to return from. supports:
 
             locations(list): list of locations to get data from.
-                If no locations are provided, defaults to NP15, SP15, and ZP26,
-                which are the trading hub locations.
-                For a list of locations, call CAISO.get_pnodes()
+            If no locations are provided, defaults to NP15, SP15, and ZP26,
+            which are the trading hub locations. For a list of locations,
+            call CAISO.get_pnodes()
 
             sleep(int): number of seconds to sleep before returning to
-                avoid hitting rate limit in regular usage.
-                Defaults to 5 seconds.
+            avoid hitting rate limit in regular usage.
+            Defaults to 5 seconds.
 
         Returns
             dataframe of pricing data
@@ -346,11 +347,11 @@ class CAISO(ISOBase):
             date: date to return data
 
             end: last date of range to return data. If None, returns only date.
-                Defaults to None.
+            Defaults to None.
 
             fuel_region_id(str, or list): single fuel region id or list of fuel
-                region ids to return data for. Defaults to ALL, which returns
-                all fuel regions.
+            region ids to return data for. Defaults to ALL, which returns
+            all fuel regions.
 
         Returns:
             dataframe of gas prices
@@ -400,8 +401,9 @@ class CAISO(ISOBase):
 
         Arguments:
             date: date to return data
+
             end: last date of range to return data.
-                If None, returns only date. Defaults to None.
+            If None, returns only date. Defaults to None.
         """
 
         start, end = _caiso_handle_start_end(date, end)
@@ -539,8 +541,10 @@ class CAISO(ISOBase):
 
         Arguments:
             date: date to return data
+
             end: last date of range to return data.
-                If None, returns only date. Defaults to None.
+            If None, returns only date. Defaults to None.
+
             verbose: print out url being fetched. Defaults to False.
 
         Returns:
@@ -669,8 +673,10 @@ class CAISO(ISOBase):
 
         Arguments:
             date: date to return data
+
             end: last date of range to return data.
-                If None, returns only date. Defaults to None.
+            If None, returns only date. Defaults to None.
+
             verbose: print out url being fetched. Defaults to False.
 
         Returns:
@@ -724,8 +730,10 @@ class CAISO(ISOBase):
 
         Arguments:
             date: date to return data
+
             end: last date of range to return data.
-                If None, returns only date. Defaults to None.
+            If None, returns only date. Defaults to None.
+
             market: DAM or RTM. Defaults to DAM.
 
         Returns:

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -67,26 +67,26 @@ class CAISO(ISOBase):
             raise NotSupported()
 
     @support_date_range(frequency="1D")
-    def get_fuel_mix(self, date, end=None, verbose=False):
-        """Get fuel mix in 5 minute intervals for a provided day
+    def get_fuel_mix(self, date, start=None, end=None, verbose=False):
+        """Get fuel mix in 5 minute intervals for a provided day CAISO
 
         Arguments:
-            date (datetime or str): "latest", "today", or an object
-            that can be parsed as a datetime for the day to return data.
+            date (datetime.date, str): "latest", "today", or an object
+                that can be parsed as a datetime for the day to return data.
 
-            start (datetime or str): start of date range to return.
-            alias for `date` parameter.
-            Only specify one of `date` or `start`.
+            start (datetime.date, str): start of date range to return.
+                alias for `date` parameter.
+                Only specify one of `date` or `start`.
 
-            end (datetime or str): "today" or an object that can be parsed
-            as a datetime for the day to return data.
-            Only used if requesting a range of dates.
+            end (datetime.date, str): "today" or an object that can be parsed
+                as a datetime for the day to return data.
+                Only used if requesting a range of dates.
 
-            verbose (bool): print verbose output. Defaults to False.
+            verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            df (pd.Dataframe): dataframe with columns: Time and columns
-            for each fuel type
+            pandas.DataFrame: A DataFrame with columns - 'Time' and columns
+            for each fuel type.
         """
         if date == "latest":
             mix = self.get_fuel_mix("today", verbose=verbose)
@@ -147,11 +147,11 @@ class CAISO(ISOBase):
         """Returns load forecast for a previous date in 1 hour intervals
 
         Arguments:
-            date(datetime, pd.Timestamp, or str): day to return.
-            If string, format should be YYYYMMDD e.g 20200623
+            date (datetime, pd.Timestamp, str): day to return.
+                If string, format should be YYYYMMDD e.g 20200623
 
-            sleep(int): number of seconds to sleep before returning to avoid
-            hitting rate limit in regular usage. Defaults to 5 seconds.
+            sleep (int): number of seconds to sleep before returning to avoid
+                hitting rate limit in regular usage. Defaults to 5 seconds.
 
         """
 
@@ -209,21 +209,20 @@ class CAISO(ISOBase):
         """Get day ahead LMP pricing starting at supplied date for a list of locations.
 
         Arguments:
-            date: date to return data
+            date (datetime.date, str): date to return data
 
             market: market to return from. supports:
 
-            locations(list): list of locations to get data from.
-            If no locations are provided, defaults to NP15, SP15, and ZP26,
-            which are the trading hub locations. For a list of locations,
-            call CAISO.get_pnodes()
+            locations (list): list of locations to get data from.
+                If no locations are provided, defaults to NP15, SP15, and ZP26,
+                which are the trading hub locations. For a list of locations,
+                call ``CAISO.get_pnodes()``
 
-            sleep(int): number of seconds to sleep before returning to
-            avoid hitting rate limit in regular usage.
-            Defaults to 5 seconds.
+            sleep (int): number of seconds to sleep before returning to
+                avoid hitting rate limit in regular usage. Defaults to 5 seconds.
 
-        Returns
-            dataframe of pricing data
+        Returns:
+            pandas.DataFrame: A DataFrame of pricing data
         """
         if date == "latest":
             return self._latest_lmp_from_today(market=market, locations=locations)
@@ -321,7 +320,7 @@ class CAISO(ISOBase):
         Negative means charging, positive means discharging
 
         Arguments:
-            date: date to return data
+            date (datetime.date, str): date to return data
         """
         if date == "latest":
             return self._latest_from_today(self.get_storage)
@@ -344,17 +343,17 @@ class CAISO(ISOBase):
         """Return gas prices at a previous date
 
         Arguments:
-            date: date to return data
+            date (datetime.date, str): date to return data
 
-            end: last date of range to return data. If None, returns only date.
-            Defaults to None.
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
 
             fuel_region_id(str, or list): single fuel region id or list of fuel
-            region ids to return data for. Defaults to ALL, which returns
-            all fuel regions.
+                region ids to return data for. Defaults to ALL, which returns
+                all fuel regions.
 
         Returns:
-            dataframe of gas prices
+            pandas.DataFrame: A DataFrame of gas prices
         """
 
         start, end = _caiso_handle_start_end(date, end)
@@ -400,10 +399,10 @@ class CAISO(ISOBase):
         """Return ghg allowance at a previous date
 
         Arguments:
-            date: date to return data
+            date (datetime.date, str): date to return data
 
-            end: last date of range to return data.
-            If None, returns only date. Defaults to None.
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
         """
 
         start, end = _caiso_handle_start_end(date, end)
@@ -540,15 +539,15 @@ class CAISO(ISOBase):
 
 
         Arguments:
-            date: date to return data
+            date (datetime.date, str): date to return data
 
-            end: last date of range to return data.
-            If None, returns only date. Defaults to None.
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
 
             verbose: print out url being fetched. Defaults to False.
 
         Returns:
-            dataframe of curtailment data
+            pandas.DataFrame: A DataFrame of curtailment data
         """
 
         # http://www.caiso.com/Documents/Wind_SolarReal-TimeDispatchCurtailmentReport02dec_2020.pdf
@@ -672,15 +671,15 @@ class CAISO(ISOBase):
         """Return AS prices for a given date for each region
 
         Arguments:
-            date: date to return data
+            date (datetime.date, str): date to return data
 
-            end: last date of range to return data.
-            If None, returns only date. Defaults to None.
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
 
-            verbose: print out url being fetched. Defaults to False.
+            verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            dataframe of AS prices
+            pandas.DataFrame: A DataFrame of AS prices
         """
 
         start, end = _caiso_handle_start_end(date, end)
@@ -729,15 +728,15 @@ class CAISO(ISOBase):
         """Get ancillary services procurement data from CAISO.
 
         Arguments:
-            date: date to return data
+            date (datetime.date, str): date to return data
 
-            end: last date of range to return data.
-            If None, returns only date. Defaults to None.
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
 
             market: DAM or RTM. Defaults to DAM.
 
         Returns:
-            dataframe of ancillary services data
+            pandas.DataFrame: A DataFrame of ancillary services data
         """
         assert market in ["DAM", "RTM"], "market must be DAM or RTM"
 

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -85,7 +85,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with columns - 'Time' and columns
+            pandas.DataFrame: A DataFrame with columns - 'Time' and columns \
                 for each fuel type.
         """
         if date == "latest":

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -147,7 +147,7 @@ class CAISO(ISOBase):
         """Returns load forecast for a previous date in 1 hour intervals
 
         Arguments:
-            date (datetime, pd.Timestamp, str): day to return.
+            date (datetime.date, pd.Timestamp, str): day to return.
                 If string, format should be YYYYMMDD e.g 20200623
 
             sleep (int): number of seconds to sleep before returning to avoid

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -92,7 +92,6 @@ class CAISO(ISOBase):
         return self._get_historical_fuel_mix(date, verbose=verbose)
 
     def _get_historical_fuel_mix(self, date, verbose=False):
-
         url = _HISTORY_BASE + "/%s/fuelsource.csv"
         df = _get_historical(url, date, verbose=verbose)
 
@@ -431,14 +430,24 @@ class CAISO(ISOBase):
 
         queue = queue.rename(
             columns={
-                "Interconnection Request\nReceive Date": "Interconnection Request Receive Date",
+                "Interconnection Request\nReceive Date": (
+                    "Interconnection Request Receive Date"
+                ),
                 "Actual\nOn-line Date": "Actual On-line Date",
                 "Current\nOn-line Date": "Current On-line Date",
-                "Interconnection Agreement \nStatus": "Interconnection Agreement Status",
+                "Interconnection Agreement \nStatus": (
+                    "Interconnection Agreement Status"
+                ),
                 "Study\nProcess": "Study Process",
-                "Proposed\nOn-line Date\n(as filed with IR)": "Proposed On-line Date (as filed with IR)",
-                "System Impact Study or \nPhase I Cluster Study": "System Impact Study or Phase I Cluster Study",
-                "Facilities Study (FAS) or \nPhase II Cluster Study": "Facilities Study (FAS) or Phase II Cluster Study",
+                "Proposed\nOn-line Date\n(as filed with IR)": (
+                    "Proposed On-line Date (as filed with IR)"
+                ),
+                "System Impact Study or \nPhase I Cluster Study": (
+                    "System Impact Study or Phase I Cluster Study"
+                ),
+                "Facilities Study (FAS) or \nPhase II Cluster Study": (
+                    "Facilities Study (FAS) or Phase II Cluster Study"
+                ),
                 "Optional Study\n(OS)": "Optional Study (OS)",
             },
         )
@@ -758,7 +767,6 @@ def _make_timestamp(time_str, today, timezone="US/Pacific"):
 
 
 def _get_historical(url, date, verbose=False):
-
     date_str = date.strftime("%Y%m%d")
     date_obj = date
     url = url % date_str

--- a/gridstatus/decorators.py
+++ b/gridstatus/decorators.py
@@ -96,11 +96,15 @@ class support_date_range:
                     args_dict["date"],
                 )
 
-            # use .date() to remove timezone info, which doesnt matter if just a date
+            # use .date() to remove timezone info, which doesnt matter
+            # if just a date
 
-            # Note: this may create a split that will end up being unnecessary after running update dates below.
-            # that is because after adding new dates, it's possible that two ranges could be added.
-            # Unnecessary optimization right now to include logic to handle this
+            # Note: this may create a split that will end up
+            # being unnecessary after running update dates below.
+            # that is because after adding new dates, it's possible that two
+            # ranges could be added.
+            # Unnecessary optimization right now to include
+            # logic to handle this
             try:
                 dates = pd.date_range(
                     args_dict["date"].date(),

--- a/gridstatus/decorators.py
+++ b/gridstatus/decorators.py
@@ -148,7 +148,6 @@ class support_date_range:
             total = len(dates) - dates.count(None) * 2 - 1
 
             with tqdm.tqdm(disable=total <= 1, total=total) as pbar:
-
                 for end_date in dates[1:]:
                     # if we come across None, it means we should reset
                     if end_date is None:

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -606,9 +606,9 @@ class Ercot(ISOBase):
         - and resetting the index
 
         Arguments:
-            pandas.DataFrame: DataFrame with SPP data
+            df (pandas.DataFrame): DataFrame with SPP data
             settlement_point_field (str): Field name of
-            settlement point to rename to "Location"
+                settlement point to rename to "Location"
         """
         df = df.rename(
             columns={

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -137,14 +137,14 @@ class Ercot(ISOBase):
         """Get fuel mix 5 minute intervals
 
         Arguments:
-            date(datetime or str): "latest", "today".
-            historical data currently not supported
+            date (datetime.date, str): "latest", "today".
+                historical data currently not supported
 
             verbose(bool): print verbose output. Defaults to False.
 
         Returns:
-            df (pd.Dataframe): dataframe with columns:
-            Time and columns for each fuel type (solar and wind)
+            pandas.DataFrame: A DataFrame with columns; Time and columns
+                for each fuel type (solar and wind)
         """
 
         if date == "latest":
@@ -306,12 +306,14 @@ class Ercot(ISOBase):
         """Get ancillary service clearing prices in hourly intervals in Day Ahead Market
 
         Arguments:
-            date(datetime or str): date of delivery for AS services
-            verbose(bool): print verbose output. Defaults to False.
+            date (datetime.date, str): date of delivery for AS services
+
+            verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            df (pd.Dataframe): dataframe with prices for "Non-Spinning Reserves",
-            "Regulation Up", "Regulation Down", "Responsive Reserves",
+
+            pandas.DataFrame: A DataFrame with prices for "Non-Spinning Reserves", \
+                "Regulation Up", "Regulation Down", "Responsive Reserves".
 
         """
         # subtract one day since it's the day ahead market happens on the day
@@ -603,9 +605,8 @@ class Ercot(ISOBase):
         - renaming and ordering columns
         - and resetting the index
 
-        Parameters:
-            df (pd.DataFrame): DataFrame with SPP data
-
+        Arguments:
+            pandas.DataFrame: DataFrame with SPP data
             settlement_point_field (str): Field name of
             settlement point to rename to "Location"
         """
@@ -721,7 +722,7 @@ class Ercot(ISOBase):
         Raises a ValueError if no document matches
 
         Returns:
-             Latest Document by publish_date
+            Latest Document by publish_date
         """
         documents = self._get_documents(
             report_type_id=report_type_id,
@@ -746,7 +747,7 @@ class Ercot(ISOBase):
         """Searches by Report Type ID, filtering for date and/or constructed name
 
         Returns:
-             list of Document with URL and Publish Date
+            list of Document with URL and Publish Date
         """
         url = f"https://www.ercot.com/misapp/servlets/IceDocListJsonWS?reportTypeId={report_type_id}"  # noqa
         if verbose:
@@ -828,7 +829,7 @@ class Ercot(ISOBase):
             raise ValueError(f"Invalid location_type: {location_type}")
 
     def _get_settlement_point_mapping(self, verbose=False):
-        """Get dataframe whose columns can help us filter out values"""
+        """Get DataFrame whose columns can help us filter out values"""
 
         doc_info = self._get_document(
             report_type_id=SETTLEMENT_POINTS_LIST_AND_ELECTRICAL_BUSES_MAPPING_RTID,

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -540,7 +540,7 @@ class Ercot(ISOBase):
             - ``REAL_TIME_15_MIN``
             - ``DAY_AHEAD_HOURLY``
 
-        Supported Location Types: 
+        Supported Location Types:
             - ``zone``
             - ``hub``
             - ``node``

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -138,13 +138,13 @@ class Ercot(ISOBase):
 
         Arguments:
             date(datetime or str): "latest", "today".
-                historical data currently not supported
+            historical data currently not supported
 
             verbose(bool): print verbose output. Defaults to False.
 
         Returns:
             df (pd.Dataframe): dataframe with columns:
-                Time and columns for each fuel type (solar and wind)
+            Time and columns for each fuel type (solar and wind)
         """
 
         if date == "latest":
@@ -311,7 +311,7 @@ class Ercot(ISOBase):
 
         Returns:
             df (pd.Dataframe): dataframe with prices for "Non-Spinning Reserves",
-                "Regulation Up", "Regulation Down", "Responsive Reserves",
+            "Regulation Up", "Regulation Down", "Responsive Reserves",
 
         """
         # subtract one day since it's the day ahead market happens on the day
@@ -605,8 +605,9 @@ class Ercot(ISOBase):
 
         Parameters:
             df (pd.DataFrame): DataFrame with SPP data
-            settlement_point_field (str):
-                Field name of settlement point to rename to "Location"
+
+            settlement_point_field (str): Field name of
+            settlement point to rename to "Location"
         """
         df = df.rename(
             columns={

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -67,7 +67,7 @@ Hub	SH	ERCOT_345KV_HUBBUSES_AVG
 Hub	AH	ERCOT_HUB_AVG
 ============================================================
 Source: https://www.ercot.com/files/docs/2009/10/26/07_tests_for_rsnable_lmps_overview_of_price_valid_tool_09102.ppt
-"""
+"""  # noqa
 RESOURCE_NODE_SETTLEMENT_TYPES = ["RN", "PCCRN", "LCCRN", "PUN"]
 LOAD_ZONE_SETTLEMENT_TYPES = ["LZ", "LZ_DC"]
 HUB_SETTLEMENT_TYPES = ["HU", "SH", "AH"]
@@ -97,7 +97,7 @@ class Ercot(ISOBase):
     ]
 
     BASE = "https://www.ercot.com/api/1/services/read/dashboards"
-    ACTUAL_LOADS_URL_FORMAT = "https://www.ercot.com/content/cdr/html/{timestamp}_actual_loads_of_forecast_zones.html"
+    ACTUAL_LOADS_URL_FORMAT = "https://www.ercot.com/content/cdr/html/{timestamp}_actual_loads_of_forecast_zones.html"  # noqa
     LOAD_HISTORICAL_MAX_DAYS = 14
 
     @dataclass
@@ -137,12 +137,14 @@ class Ercot(ISOBase):
         """Get fuel mix 5 minute intervals
 
         Arguments:
-            date(datetime or str): "latest", "today". historical data currently not supported
+            date(datetime or str): "latest", "today".
+                historical data currently not supported
 
             verbose(bool): print verbose output. Defaults to False.
 
         Returns:
-            pd.Dataframe: dataframe with columns: Time and columns for each fuel type (solar and wind)
+            df (pd.Dataframe): dataframe with columns:
+                Time and columns for each fuel type (solar and wind)
         """
 
         if date == "latest":
@@ -308,10 +310,12 @@ class Ercot(ISOBase):
             verbose(bool): print verbose output. Defaults to False.
 
         Returns:
-            pd.Dataframe: dataframe with prices for "Non-Spinning Reserves", "Regulation Up", "Regulation Down", "Responsive Reserves",
+            df (pd.Dataframe): dataframe with prices for "Non-Spinning Reserves",
+                "Regulation Up", "Regulation Down", "Responsive Reserves",
 
         """
-        # subtract one day since it's the day ahead market happens on the day before for the delivery day
+        # subtract one day since it's the day ahead market happens on the day
+        # before for the delivery day
         date = date - pd.Timedelta("1D")
 
         doc_info = self._get_document(
@@ -359,13 +363,15 @@ class Ercot(ISOBase):
         return data
 
     def get_rtm_spp(self, year):
-        """Get Historical RTM Settlement Point Prices(SPPs) for each of the Hubs and Load Zones
+        """Get Historical RTM Settlement Point Prices(SPPs)
+            for each of the Hubs and Load Zones
 
         Arguments:
             year(int): year to get data for
 
-        Source: https: // www.ercot.com/mp/data-products/data-product-details?id = NP6-785-ER
-        """
+        Source:
+            https://www.ercot.com/mp/data-products/data-product-details?id=NP6-785-ER
+        """  # noqa
         doc_info = self._get_document(
             report_type_id=HISTORICAL_RTM_LOAD_ZONE_AND_HUB_PRICES_RTID,
             constructed_name_contains=f"{year}.zip",
@@ -378,10 +384,12 @@ class Ercot(ISOBase):
         return df
 
     def get_interconnection_queue(self, verbose=False):
-        """Get interconnection queue for ERCOT
-
-        Monthly historical data available here: http: // mis.ercot.com/misapp/GetReports.do?reportTypeId = 15933 & reportTitle = GIS % 20Report & showHTMLView = &mimicKey
         """
+        Get interconnection queue for ERCOT
+
+        Monthly historical data available here:
+            http://mis.ercot.com/misapp/GetReports.do?reportTypeId=15933&reportTitle=GIS%20Report&showHTMLView=&mimicKey
+        """  # noqa
 
         doc_info = self._get_document(
             report_type_id=GIS_REPORT_RTID,
@@ -470,7 +478,8 @@ class Ercot(ISOBase):
             "Status": "Status",
         }
 
-        # todo: there are a few columns being parsed as "unamed" that aren't being included but should
+        # todo: there are a few columns being parsed
+        # as "unamed" that aren't being included but should
         extra_columns = [
             "Fuel",
             "Technology",
@@ -495,7 +504,8 @@ class Ercot(ISOBase):
         ]
 
         missing = [
-            # todo the actual complettion date can be calculated by looking at status and other date columns
+            # todo the actual complettion date can be calculated by
+            # looking at status and other date columns
             "Withdrawal Comment",
             "Transmission Owner",
             "Summer Capacity (MW)",
@@ -594,8 +604,9 @@ class Ercot(ISOBase):
         - and resetting the index
 
         Parameters:
-            df (DataFrame): DataFrame with SPP data
-            settlement_point_field (str): Field name of settlement point to rename to "Location"
+            df (pd.DataFrame): DataFrame with SPP data
+            settlement_point_field (str):
+                Field name of settlement point to rename to "Location"
         """
         df = df.rename(
             columns={
@@ -736,7 +747,7 @@ class Ercot(ISOBase):
         Returns:
              list of Document with URL and Publish Date
         """
-        url = f"https://www.ercot.com/misapp/servlets/IceDocListJsonWS?reportTypeId={report_type_id}"
+        url = f"https://www.ercot.com/misapp/servlets/IceDocListJsonWS?reportTypeId={report_type_id}"  # noqa
         if verbose:
             print(f"Fetching document {url}", file=sys.stderr)
         docs = self._get_json(url)["ListDocsByRptTypeRes"]["DocumentList"]
@@ -759,7 +770,7 @@ class Ercot(ISOBase):
 
             if match:
                 doc_id = doc["Document"]["DocID"]
-                url = f"https://www.ercot.com/misdownload/servlets/mirDownload?doclookupId={doc_id}"
+                url = f"https://www.ercot.com/misdownload/servlets/mirDownload?doclookupId={doc_id}"  # noqa
                 matches.append(
                     self.Document(
                         url=url,

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -536,9 +536,14 @@ class Ercot(ISOBase):
     ):
         """Get SPP data for ERCOT
 
-        Supported Markets: REAL_TIME_15_MIN, DAY_AHEAD_HOURLY
+        Supported Markets:
+            - ``REAL_TIME_15_MIN``
+            - ``DAY_AHEAD_HOURLY``
 
-        Supported Location Types: "zone", "hub", "node"
+        Supported Location Types: 
+            - ``zone``
+            - ``hub``
+            - ``node``
         """
         assert market is not None, "market must be specified"
         market = Markets(market)

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -143,8 +143,8 @@ class Ercot(ISOBase):
             verbose(bool): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with columns; Time and columns
-                for each fuel type (solar and wind)
+            pandas.DataFrame: A DataFrame with columns; Time and columns for each fuel \
+                type (solar and wind)
         """
 
         if date == "latest":

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -23,7 +23,7 @@ class ISONE(ISOBase):
     iso_id = "isone"
     default_timezone = "US/Eastern"
 
-    status_homepage = "https://www.iso-ne.com/markets-operations/system-forecast-status/current-system-status"
+    status_homepage = "https://www.iso-ne.com/markets-operations/system-forecast-status/current-system-status" # noqa
     interconnection_homepage = "https://irtt.iso-ne.com/reports/external"
 
     markets = [
@@ -147,7 +147,7 @@ class ISONE(ISOBase):
             return self._latest_from_today(self.get_load)
 
         date_str = date.strftime("%Y%m%d")
-        url = f"https://www.iso-ne.com/transform/csv/fiveminutesystemload?start={date_str}&end={date_str}"
+        url = f"https://www.iso-ne.com/transform/csv/fiveminutesystemload?start={date_str}&end={date_str}" # noqa
         data = _make_request(url, skiprows=[0, 1, 2, 3, 5], verbose=verbose)
 
         data["Date/Time"] = pd.to_datetime(data["Date/Time"]).dt.tz_localize(
@@ -210,16 +210,16 @@ class ISONE(ISOBase):
 
     def _get_latest_lmp(self, market: str, locations: list = None, verbose=False):
         """
-        Find Node ID mapping: https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/
-        """
+        Find Node ID mapping: https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/ 
+        """ # noqa
         if locations is None:
             locations = "ALL"
         market = Markets(market)
         if market == Markets.REAL_TIME_5_MIN:
-            url = "https://www.iso-ne.com/transform/csv/fiveminlmp/current?type=prelim"
+            url = "https://www.iso-ne.com/transform/csv/fiveminlmp/current?type=prelim" # noqa
             data = _make_request(url, skiprows=[0, 1, 2, 4], verbose=verbose)
         elif market == Markets.REAL_TIME_HOURLY:
-            url = "https://www.iso-ne.com/transform/csv/hourlylmp/current?type=prelim&market=rt"
+            url = "https://www.iso-ne.com/transform/csv/hourlylmp/current?type=prelim&market=rt" # noqa
             data = _make_request(url, skiprows=[0, 1, 2, 4], verbose=verbose)
 
             # todo does this handle single digital hours?
@@ -251,8 +251,10 @@ class ISONE(ISOBase):
         include_id=False,
         verbose=False,
     ):
-        """Find Node ID mapping: https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/
         """
+        Find Node ID mapping: 
+            https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/
+        """# noqa
 
         if date == "latest":
             return self._get_latest_lmp(
@@ -281,7 +283,7 @@ class ISONE(ISOBase):
             dfs = []
             for interval in intervals:
                 print("Loading interval {}".format(interval))
-                u = f"https://www.iso-ne.com/static-transform/csv/histRpts/5min-rt-prelim/lmp_5min_{date_str}_{interval}.csv"
+                u = f"https://www.iso-ne.com/static-transform/csv/histRpts/5min-rt-prelim/lmp_5min_{date_str}_{interval}.csv" # noqa
                 dfs.append(
                     pd.read_csv(
                         u,
@@ -303,9 +305,10 @@ class ISONE(ISOBase):
 
             # add current interval
             if now.date() == date.date():
-                url = "https://www.iso-ne.com/transform/csv/fiveminlmp/currentrollinginterval"
+                url = "https://www.iso-ne.com/transform/csv/fiveminlmp/currentrollinginterval" # noqa
                 print("Loading current interval")
-                # this request is very very slow for some reason. I suspect because the server is making the response dynamically
+                # this request is very very slow for some reason. 
+                # I suspect b/c the server is making the response dynamically
                 data_current = _make_request(
                     url,
                     skiprows=[0, 1, 2, 4],
@@ -318,7 +321,7 @@ class ISONE(ISOBase):
 
         elif market == Markets.REAL_TIME_HOURLY:
             if date.date() < now.date():
-                url = f"https://www.iso-ne.com/static-transform/csv/histRpts/rt-lmp/lmp_rt_prelim_{date_str}.csv"
+                url = f"https://www.iso-ne.com/static-transform/csv/histRpts/rt-lmp/lmp_rt_prelim_{date_str}.csv" # noqa
                 data = _make_request(
                     url,
                     skiprows=[0, 1, 2, 3, 5],
@@ -346,7 +349,7 @@ class ISONE(ISOBase):
                 )
 
         elif market == Markets.DAY_AHEAD_HOURLY:
-            url = f"https://www.iso-ne.com/static-transform/csv/histRpts/da-lmp/WW_DALMP_ISO_{date_str}.csv"
+            url = f"https://www.iso-ne.com/static-transform/csv/histRpts/da-lmp/WW_DALMP_ISO_{date_str}.csv" # noqa
             data = _make_request(
                 url,
                 skiprows=[0, 1, 2, 3, 5],
@@ -470,9 +473,10 @@ class ISONE(ISOBase):
         Returns:
             pd.DataFrame -- interconnection queue
 
-        """
-        # not sure what the reportdate value is. it is hardcode into the javascript to add and doesnt work without
-        url = "https://irtt.iso-ne.com/reports/exportpublicqueue?ReportDate=638005248000000000&Status=&Jurisdiction="
+        """# noqa
+        # not sure what the reportdate value is. 
+        # it is hardcode into the javascript to add and doesnt work without
+        url = "https://irtt.iso-ne.com/reports/exportpublicqueue?ReportDate=638005248000000000&Status=&Jurisdiction=" # noqa
 
         if verbose:
             print("Loading interconnection queue from {}".format(url))
@@ -512,7 +516,8 @@ class ISONE(ISOBase):
             "TO Report": "Transmission Owner",
         }
 
-        # todo: there are a few columns being parsed as "unamed" that aren't being included but should
+        # todo: there are a few columns being parsed as "unamed" 
+        # that aren't being included but should
         extra_columns = [
             "Updated",
             "Unit",
@@ -533,7 +538,8 @@ class ISONE(ISOBase):
 
         missing = [
             "Interconnecting Entity",
-            "Actual Completion Date",  # because there are only activate and withdrawn projects
+            "Actual Completion Date",  
+            # because there are only activate and withdrawn projects
             "Withdrawal Comment",
         ]
 

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -23,7 +23,7 @@ class ISONE(ISOBase):
     iso_id = "isone"
     default_timezone = "US/Eastern"
 
-    status_homepage = "https://www.iso-ne.com/markets-operations/system-forecast-status/current-system-status" # noqa
+    status_homepage = "https://www.iso-ne.com/markets-operations/system-forecast-status/current-system-status"  # noqa
     interconnection_homepage = "https://irtt.iso-ne.com/reports/external"
 
     markets = [
@@ -147,7 +147,7 @@ class ISONE(ISOBase):
             return self._latest_from_today(self.get_load)
 
         date_str = date.strftime("%Y%m%d")
-        url = f"https://www.iso-ne.com/transform/csv/fiveminutesystemload?start={date_str}&end={date_str}" # noqa
+        url = f"https://www.iso-ne.com/transform/csv/fiveminutesystemload?start={date_str}&end={date_str}"  # noqa
         data = _make_request(url, skiprows=[0, 1, 2, 3, 5], verbose=verbose)
 
         data["Date/Time"] = pd.to_datetime(data["Date/Time"]).dt.tz_localize(
@@ -210,16 +210,16 @@ class ISONE(ISOBase):
 
     def _get_latest_lmp(self, market: str, locations: list = None, verbose=False):
         """
-        Find Node ID mapping: https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/ 
-        """ # noqa
+        Find Node ID mapping: https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/
+        """  # noqa
         if locations is None:
             locations = "ALL"
         market = Markets(market)
         if market == Markets.REAL_TIME_5_MIN:
-            url = "https://www.iso-ne.com/transform/csv/fiveminlmp/current?type=prelim" # noqa
+            url = "https://www.iso-ne.com/transform/csv/fiveminlmp/current?type=prelim"  # noqa
             data = _make_request(url, skiprows=[0, 1, 2, 4], verbose=verbose)
         elif market == Markets.REAL_TIME_HOURLY:
-            url = "https://www.iso-ne.com/transform/csv/hourlylmp/current?type=prelim&market=rt" # noqa
+            url = "https://www.iso-ne.com/transform/csv/hourlylmp/current?type=prelim&market=rt"  # noqa
             data = _make_request(url, skiprows=[0, 1, 2, 4], verbose=verbose)
 
             # todo does this handle single digital hours?
@@ -252,9 +252,9 @@ class ISONE(ISOBase):
         verbose=False,
     ):
         """
-        Find Node ID mapping: 
+        Find Node ID mapping:
             https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/
-        """# noqa
+        """  # noqa
 
         if date == "latest":
             return self._get_latest_lmp(
@@ -283,7 +283,7 @@ class ISONE(ISOBase):
             dfs = []
             for interval in intervals:
                 print("Loading interval {}".format(interval))
-                u = f"https://www.iso-ne.com/static-transform/csv/histRpts/5min-rt-prelim/lmp_5min_{date_str}_{interval}.csv" # noqa
+                u = f"https://www.iso-ne.com/static-transform/csv/histRpts/5min-rt-prelim/lmp_5min_{date_str}_{interval}.csv"  # noqa
                 dfs.append(
                     pd.read_csv(
                         u,
@@ -305,9 +305,9 @@ class ISONE(ISOBase):
 
             # add current interval
             if now.date() == date.date():
-                url = "https://www.iso-ne.com/transform/csv/fiveminlmp/currentrollinginterval" # noqa
+                url = "https://www.iso-ne.com/transform/csv/fiveminlmp/currentrollinginterval"  # noqa
                 print("Loading current interval")
-                # this request is very very slow for some reason. 
+                # this request is very very slow for some reason.
                 # I suspect b/c the server is making the response dynamically
                 data_current = _make_request(
                     url,
@@ -321,7 +321,7 @@ class ISONE(ISOBase):
 
         elif market == Markets.REAL_TIME_HOURLY:
             if date.date() < now.date():
-                url = f"https://www.iso-ne.com/static-transform/csv/histRpts/rt-lmp/lmp_rt_prelim_{date_str}.csv" # noqa
+                url = f"https://www.iso-ne.com/static-transform/csv/histRpts/rt-lmp/lmp_rt_prelim_{date_str}.csv"  # noqa
                 data = _make_request(
                     url,
                     skiprows=[0, 1, 2, 3, 5],
@@ -349,7 +349,7 @@ class ISONE(ISOBase):
                 )
 
         elif market == Markets.DAY_AHEAD_HOURLY:
-            url = f"https://www.iso-ne.com/static-transform/csv/histRpts/da-lmp/WW_DALMP_ISO_{date_str}.csv" # noqa
+            url = f"https://www.iso-ne.com/static-transform/csv/histRpts/da-lmp/WW_DALMP_ISO_{date_str}.csv"  # noqa
             data = _make_request(
                 url,
                 skiprows=[0, 1, 2, 3, 5],
@@ -473,10 +473,10 @@ class ISONE(ISOBase):
         Returns:
             pd.DataFrame -- interconnection queue
 
-        """# noqa
-        # not sure what the reportdate value is. 
+        """  # noqa
+        # not sure what the reportdate value is.
         # it is hardcode into the javascript to add and doesnt work without
-        url = "https://irtt.iso-ne.com/reports/exportpublicqueue?ReportDate=638005248000000000&Status=&Jurisdiction=" # noqa
+        url = "https://irtt.iso-ne.com/reports/exportpublicqueue?ReportDate=638005248000000000&Status=&Jurisdiction="  # noqa
 
         if verbose:
             print("Loading interconnection queue from {}".format(url))
@@ -516,7 +516,7 @@ class ISONE(ISOBase):
             "TO Report": "Transmission Owner",
         }
 
-        # todo: there are a few columns being parsed as "unamed" 
+        # todo: there are a few columns being parsed as "unamed"
         # that aren't being included but should
         extra_columns = [
             "Updated",
@@ -538,7 +538,7 @@ class ISONE(ISOBase):
 
         missing = [
             "Interconnecting Entity",
-            "Actual Completion Date",  
+            "Actual Completion Date",
             # because there are only activate and withdrawn projects
             "Withdrawal Comment",
         ]
@@ -578,8 +578,7 @@ def _make_request(url, skiprows, verbose):
 
         if r2.status_code != 200:
             raise RuntimeError(
-                "Failed to get data from {}. Check if ISONE is down and try again later"
-                .format(
+                "Failed to get data from {}. Check if ISONE is down and try again later".format(
                     url,
                 ),
             )
@@ -605,8 +604,7 @@ def _make_wsclient_request(url, data, verbose=False):
 
     if r.status_code != 200:
         raise RuntimeError(
-            "Failed to get data from {}. Check if ISONE is down and try again later"
-            .format(
+            "Failed to get data from {}. Check if ISONE is down and try again later".format(
                 url,
             ),
         )

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -578,9 +578,8 @@ def _make_request(url, skiprows, verbose):
 
         if r2.status_code != 200:
             raise RuntimeError(
-                "Failed to get data from {}. Check if ISONE is down and try again later".format(
-                    url,
-                ),
+                f"Failed to get data from {url}. Check if ISONE is down and \
+                    try again later",
             )
 
         df = pd.read_csv(
@@ -604,9 +603,8 @@ def _make_wsclient_request(url, data, verbose=False):
 
     if r.status_code != 200:
         raise RuntimeError(
-            "Failed to get data from {}. Check if ISONE is down and try again later".format(
-                url,
-            ),
+            f"Failed to get data from {url}. Check if ISONE is down and \
+                try again later",
         )
 
     return r.json()

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -471,7 +471,7 @@ class ISONE(ISOBase):
 
 
         Returns:
-            pd.DataFrame -- interconnection queue
+            pandas.DataFrame: interconnection queue
 
         """  # noqa
         # not sure what the reportdate value is.

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -251,7 +251,8 @@ class ISONE(ISOBase):
         include_id=False,
         verbose=False,
     ):
-        """Find Node ID mapping: https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/"""
+        """Find Node ID mapping: https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/
+        """
 
         if date == "latest":
             return self._get_latest_lmp(
@@ -571,7 +572,8 @@ def _make_request(url, skiprows, verbose):
 
         if r2.status_code != 200:
             raise RuntimeError(
-                "Failed to get data from {}. Check if ISONE is down and try again later".format(
+                "Failed to get data from {}. Check if ISONE is down and try again later"
+                .format(
                     url,
                 ),
             )
@@ -597,7 +599,8 @@ def _make_wsclient_request(url, data, verbose=False):
 
     if r.status_code != 200:
         raise RuntimeError(
-            "Failed to get data from {}. Check if ISONE is down and try again later".format(
+            "Failed to get data from {}. Check if ISONE is down and try again later"
+            .format(
                 url,
             ),
         )

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -2,7 +2,6 @@ import io
 import math
 import sys
 
-
 import pandas as pd
 import requests
 

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -1,13 +1,9 @@
 import io
 import math
-import re
-from heapq import merge
-from tabnanny import verbose
 
 import pandas as pd
 import requests
 
-import gridstatus
 from gridstatus import utils
 from gridstatus.base import (
     FuelMix,
@@ -558,7 +554,7 @@ def _make_request(url, skiprows, verbose):
         attempt = 0
         while attempt < 3:
             # make first get request to get cookies set
-            r1 = s.get(
+            _ = s.get(
                 "https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/gen-fuel-mix",
             )
 

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -36,6 +36,17 @@ class MISO(ISOBase):
     ]
 
     def get_fuel_mix(self, date, verbose=False):
+        """_summary_
+
+        Arguments:
+            date (datetime.date, str): "latest", "today", or an object
+                that can be parsed as a datetime for the day to return data.
+
+            verbose (bool, optional): print verbose output. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: DataFrame with columns "Time", "Load", "Fuel Mix"
+        """
         if date != "latest":
             raise NotSupported()
 
@@ -189,7 +200,7 @@ class MISO(ISOBase):
         """Get the interconnection queue
 
         Returns:
-            pd.DataFrame -- Interconnection queue
+            pandas.DataFrame: Interconnection queue
         """
         url = "https://www.misoenergy.org/api/giqueue/getprojects"
 

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -129,8 +129,8 @@ class MISO(ISOBase):
     def get_lmp(self, date, market: str, locations: list = None, verbose=False):
         """
         Supported Markets:
-            - REAL_TIME_5_MIN (FiveMinLMP)
-            - DAY_AHEAD_HOURLY (DayAheadExPostLMP)
+            - ``REAL_TIME_5_MIN`` - (FiveMinLMP)
+            - ``DAY_AHEAD_HOURLY`` - (DayAheadExPostLMP)
         """
         if date != "latest":
             raise NotSupported()

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -87,7 +87,6 @@ class MISO(ISOBase):
             raise NotSupported
 
     def get_load_forecast(self, date, verbose=False):
-
         if date != "today":
             raise NotSupported()
 

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -2,7 +2,6 @@ import json
 
 import pandas as pd
 import requests
-from pandas import Timestamp
 
 from gridstatus import utils
 from gridstatus.base import FuelMix, ISOBase, Markets, NotSupported

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -36,7 +36,7 @@ class MISO(ISOBase):
     ]
 
     def get_fuel_mix(self, date, verbose=False):
-        """_summary_
+        """Get the fuel mix for a given day for a provided MISO.
 
         Arguments:
             date (datetime.date, str): "latest", "today", or an object
@@ -129,9 +129,8 @@ class MISO(ISOBase):
     def get_lmp(self, date, market: str, locations: list = None, verbose=False):
         """
         Supported Markets:
-
-        REAL_TIME_5_MIN (FiveMinLMP)
-        DAY_AHEAD_HOURLY (DayAheadExPostLMP)
+            - REAL_TIME_5_MIN (FiveMinLMP)
+            - DAY_AHEAD_HOURLY (DayAheadExPostLMP)
         """
         if date != "latest":
             raise NotSupported()

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -111,7 +111,7 @@ class MISO(ISOBase):
         return df
 
     def _get_load_and_forecast_data(self, verbose=False):
-        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=gettotalload&returnType=json"
+        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=gettotalload&returnType=json" # noqa
         r = self._get_json(url, verbose=verbose)
         return r
 
@@ -128,7 +128,7 @@ class MISO(ISOBase):
         if locations is None:
             locations = "ALL"
 
-        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getLMPConsolidatedTable&returnType=json"
+        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getLMPConsolidatedTable&returnType=json" # noqa
         r = self._get_json(url, verbose=verbose)
 
         time = r["LMPData"]["RefId"]
@@ -250,7 +250,8 @@ class MISO(ISOBase):
         ]
 
         missing = [
-            # todo the actual complettion date can be calculated by looking at status and other date columns
+            # todo the actual complettion date
+            # can be calculated by looking at status and other date columns
             "Actual Completion Date",
             "Withdrawal Comment",
             "Project Name",
@@ -278,4 +279,4 @@ historical fuel mix: https://www.misoenergy.org/markets-and-operations/real-time
 
 - ancillary services available in consolidate api
 
-"""
+"""# noqa

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -111,7 +111,7 @@ class MISO(ISOBase):
         return df
 
     def _get_load_and_forecast_data(self, verbose=False):
-        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=gettotalload&returnType=json" # noqa
+        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=gettotalload&returnType=json"  # noqa
         r = self._get_json(url, verbose=verbose)
         return r
 
@@ -128,7 +128,7 @@ class MISO(ISOBase):
         if locations is None:
             locations = "ALL"
 
-        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getLMPConsolidatedTable&returnType=json" # noqa
+        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getLMPConsolidatedTable&returnType=json"  # noqa
         r = self._get_json(url, verbose=verbose)
 
         time = r["LMPData"]["RefId"]
@@ -279,4 +279,4 @@ historical fuel mix: https://www.misoenergy.org/markets-and-operations/real-time
 
 - ancillary services available in consolidate api
 
-"""# noqa
+"""  # noqa

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -173,9 +173,13 @@ class NYISO(ISOBase):
         verbose=False,
     ):
         """
-        Supported Markets: REAL_TIME_5_MIN, DAY_AHEAD_HOURLY
+        Supported Markets:
+            - ``REAL_TIME_5_MIN``
+            - ``DAY_AHEAD_HOURLY``
 
-        Supported Location Types: "zone", "generator"
+        Supported Location Types: 
+            - ``zone``
+            - ``generator``
         """
         if date == "latest":
             return self._latest_lmp_from_today(
@@ -241,8 +245,8 @@ class NYISO(ISOBase):
         Additional Non-NYISO queue info: https://www3.dps.ny.gov/W/PSCWeb.nsf/All/286D2C179E9A5A8385257FBF003F1F7E?OpenDocument
 
         Returns:
-            pandas.DataFrame: Interconnection queue containing, active, withdrawn,
-            and completed project
+            pandas.DataFrame: Interconnection queue containing, active, withdrawn, \
+                and completed project
 
         """  # noqa
 
@@ -669,9 +673,8 @@ class NYISO(ISOBase):
             verbose (bool, optional): print out requested url. Defaults to False.
 
         Returns:
-            pandas.DataFrame: a DataFrame of monthly capacity prices
-                (all three auctions) for each of the four capacity localities
-                within NYISO
+            a DataFrame of monthly capacity prices (all three auctions) for \
+                each of the four capacity localities within NYISO
         """
         if date is None:
             date = pd.Timestamp.now(tz=self.default_timezone)

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -17,7 +17,8 @@ from gridstatus.decorators import support_date_range
 
 ZONE = "zone"
 GENERATOR = "generator"
-"""NYISO offers LMP data at two locational granularities: load zone and point of generator interconnection"""
+"""NYISO offers LMP data at two locational granularities: \
+    load zone and point of generator interconnection"""
 
 
 class NYISO(ISOBase):
@@ -84,7 +85,10 @@ class NYISO(ISOBase):
 
             if data["status"] != "success":
                 raise RuntimeError(
-                    "Failed to get latest fuel mix. Check if NYISO's API is down.",
+                    (
+                        "Failed to get latest fuel mix. Check if                       "
+                        "  NYISO's API is down."
+                    ),
                 )
 
             mix_df = pd.DataFrame(data["data"])
@@ -237,13 +241,14 @@ class NYISO(ISOBase):
         Additional Non-NYISO queue info: https://www3.dps.ny.gov/W/PSCWeb.nsf/All/286D2C179E9A5A8385257FBF003F1F7E?OpenDocument
 
         Returns:
-            pd.DataFrame: Interconnection queue containing, active, withdrawn, and completed project
+            pd.DataFrame: Interconnection queue containing, active, withdrawn,
+                and completed project
 
-        """
+        """  # noqa
 
         # 3 sheets - ['Interconnection Queue', 'Withdrawn', 'In Service']
         # harded coded for now. perhaps this url can be parsed from the html here:
-        url = "https://www.nyiso.com/documents/20142/1407078/NYISO-Interconnection-Queue.xlsx"
+        url = "https://www.nyiso.com/documents/20142/1407078/NYISO-Interconnection-Queue.xlsx"  # noqa
 
         if verbose:
             print("Downloading interconnection queue from {}".format(url))
@@ -347,7 +352,8 @@ class NYISO(ISOBase):
         )
 
         # TODO handle other 2 sheets
-        # TODO they publish past queues, but not sure what data is in them that is relevant
+        # TODO they publish past queues,
+        # but not sure what data is in them that is relevant
 
         rename = {
             "Queue Pos.": "Queue ID",
@@ -428,7 +434,7 @@ class NYISO(ISOBase):
 
         # need to be updated once a year. approximately around end of april
         # find it here: https://www.nyiso.com/gold-book-resources
-        capacity_url_2022 = "https://www.nyiso.com/documents/20142/30338270/2022-NYCA-Generators.xlsx/f0526021-37fd-2c27-94ee-14d0f31878c1"
+        capacity_url_2022 = "https://www.nyiso.com/documents/20142/30338270/2022-NYCA-Generators.xlsx/f0526021-37fd-2c27-94ee-14d0f31878c1"  # noqa
 
         if verbose:
             print(f"Requesting {url}")
@@ -657,18 +663,23 @@ class NYISO(ISOBase):
         """Pull the most recent capacity market report's market clearing prices
 
         Parameters:
-            date (pd.Timestamp): date that will be used to pull latest capacity report (will refer to month and year)
+            date (pd.Timestamp): date that will be used to pull latest capacity
+                report (will refer to month and year)
             verbose (bool): print out requested url
 
         Returns:
-            pd.DataFrame: a dataframe of monthly capacity prices (all three auctions) for each of the four capacity localities within NYISO
+            pd.DataFrame: a dataframe of monthly capacity prices
+                (all three auctions) for each of the four capacity localities
+                within NYISO
         """
         if date is None:
             date = pd.Timestamp.now(tz=self.default_timezone)
         else:
             date = utils._handle_date(date, tz=self.default_timezone)
 
-        # todo: it looks like the "27447313" component of the base URL changes every year but I'm not sure what the link between that and the year is...
+        # todo: it looks like the "27447313" component of the base URL changes
+        # every year but I'm not sure what the link between that and the year
+        # is...
         capacity_market_base_url = (
             "https://www.nyiso.com/documents/20142/27447313/ICAP-Market-Report"
         )

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -242,7 +242,7 @@ class NYISO(ISOBase):
 
         Returns:
             df (pd.Dataframe): Interconnection queue containing, active, withdrawn,
-                and completed project
+            and completed project
 
         """  # noqa
 
@@ -664,13 +664,14 @@ class NYISO(ISOBase):
 
         Parameters:
             date (pd.Timestamp): date that will be used to pull latest capacity
-                report (will refer to month and year)
+            report (will refer to month and year)
+
             verbose (bool): print out requested url
 
         Returns:
             df (pd.Dataframe): a dataframe of monthly capacity prices
-                (all three auctions) for each of the four capacity localities
-                within NYISO
+            (all three auctions) for each of the four capacity localities
+            within NYISO
         """
         if date is None:
             date = pd.Timestamp.now(tz=self.default_timezone)

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -241,7 +241,7 @@ class NYISO(ISOBase):
         Additional Non-NYISO queue info: https://www3.dps.ny.gov/W/PSCWeb.nsf/All/286D2C179E9A5A8385257FBF003F1F7E?OpenDocument
 
         Returns:
-            df (pd.Dataframe): Interconnection queue containing, active, withdrawn,
+            pandas.DataFrame: Interconnection queue containing, active, withdrawn,
             and completed project
 
         """  # noqa
@@ -391,11 +391,11 @@ class NYISO(ISOBase):
 
         When possible return capacity and fuel type information
 
-        Parameters:
-            verbose (bool): print out requested url
+        Arguments:
+            verbose (bool, optional): print out requested url
 
         Returns:
-            df (pd.Dataframe): a dataframe of generators and locations
+            pandas.DataFrame: a DataFrame of generators and locations
 
             **Possible Columns**
 
@@ -550,11 +550,11 @@ class NYISO(ISOBase):
     def get_loads(self, verbose=False):
         """Get a list of loads in NYISO
 
-        Parameters:
-            verbose (bool): print out requested url
+        Arguments:
+            verbose (bool, optional): print out requested url
 
         Returns:
-            df (pd.Dataframe): a dataframe of loads and locations
+            pandas.DataFrame: a DataFrame of loads and locations
         """
 
         url = "http://mis.nyiso.com/public/csv/load/load.csv"
@@ -662,14 +662,14 @@ class NYISO(ISOBase):
     def get_capacity_prices(self, date=None, verbose=False):
         """Pull the most recent capacity market report's market clearing prices
 
-        Parameters:
-            date (pd.Timestamp): date that will be used to pull latest capacity
+        Arguments:
+            date (pandas.Timestamp): date that will be used to pull latest capacity
             report (will refer to month and year)
 
-            verbose (bool): print out requested url
+            verbose (bool, optional): print out requested url
 
         Returns:
-            df (pd.Dataframe): a dataframe of monthly capacity prices
+            pandas.DataFrame: a DataFrame of monthly capacity prices
             (all three auctions) for each of the four capacity localities
             within NYISO
         """

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -12,7 +12,6 @@ from gridstatus.base import (
     InterconnectionQueueStatus,
     ISOBase,
     Markets,
-    _interconnection_columns,
 )
 from gridstatus.decorators import support_date_range
 
@@ -86,7 +85,7 @@ class NYISO(ISOBase):
 
             if data["status"] != "success":
                 raise RuntimeError(
-                    f"Failed to get latest fuel mix. Check if NYISO's API is down.",
+                    "Failed to get latest fuel mix. Check if NYISO's API is down.",
                 )
 
             mix_df = pd.DataFrame(data["data"])

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -392,7 +392,7 @@ class NYISO(ISOBase):
         When possible return capacity and fuel type information
 
         Arguments:
-            verbose (bool, optional): print out requested url
+            verbose (bool, optional): print out requested url. Defaults to False.
 
         Returns:
             pandas.DataFrame: a DataFrame of generators and locations
@@ -551,7 +551,7 @@ class NYISO(ISOBase):
         """Get a list of loads in NYISO
 
         Arguments:
-            verbose (bool, optional): print out requested url
+            verbose (bool, optional): print out requested url. Defaults to False.
 
         Returns:
             pandas.DataFrame: a DataFrame of loads and locations
@@ -666,7 +666,7 @@ class NYISO(ISOBase):
             date (pandas.Timestamp): date that will be used to pull latest capacity
             report (will refer to month and year)
 
-            verbose (bool, optional): print out requested url
+            verbose (bool, optional): print out requested url. Defaults to False.
 
         Returns:
             pandas.DataFrame: a DataFrame of monthly capacity prices

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -241,7 +241,7 @@ class NYISO(ISOBase):
         Additional Non-NYISO queue info: https://www3.dps.ny.gov/W/PSCWeb.nsf/All/286D2C179E9A5A8385257FBF003F1F7E?OpenDocument
 
         Returns:
-            pd.DataFrame: Interconnection queue containing, active, withdrawn,
+            df (pd.Dataframe): Interconnection queue containing, active, withdrawn,
                 and completed project
 
         """  # noqa
@@ -395,7 +395,7 @@ class NYISO(ISOBase):
             verbose (bool): print out requested url
 
         Returns:
-            pd.DataFrame: a dataframe of generators and locations
+            df (pd.Dataframe): a dataframe of generators and locations
 
             **Possible Columns**
 
@@ -554,7 +554,7 @@ class NYISO(ISOBase):
             verbose (bool): print out requested url
 
         Returns:
-            pd.DataFrame: a dataframe of loads and locations
+            df (pd.Dataframe): a dataframe of loads and locations
         """
 
         url = "http://mis.nyiso.com/public/csv/load/load.csv"
@@ -668,7 +668,7 @@ class NYISO(ISOBase):
             verbose (bool): print out requested url
 
         Returns:
-            pd.DataFrame: a dataframe of monthly capacity prices
+            df (pd.Dataframe): a dataframe of monthly capacity prices
                 (all three auctions) for each of the four capacity localities
                 within NYISO
         """

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -177,7 +177,7 @@ class NYISO(ISOBase):
             - ``REAL_TIME_5_MIN``
             - ``DAY_AHEAD_HOURLY``
 
-        Supported Location Types: 
+        Supported Location Types:
             - ``zone``
             - ``generator``
         """

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -664,14 +664,14 @@ class NYISO(ISOBase):
 
         Arguments:
             date (pandas.Timestamp): date that will be used to pull latest capacity
-            report (will refer to month and year)
+                report (will refer to month and year)
 
             verbose (bool, optional): print out requested url. Defaults to False.
 
         Returns:
             pandas.DataFrame: a DataFrame of monthly capacity prices
-            (all three auctions) for each of the four capacity localities
-            within NYISO
+                (all three auctions) for each of the four capacity localities
+                within NYISO
         """
         if date is None:
             date = pd.Timestamp.now(tz=self.default_timezone)

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -32,7 +32,6 @@ class NYISO(ISOBase):
 
     @support_date_range(frequency="MS")
     def get_status(self, date, end=None, verbose=False):
-
         if date == "latest":
             latest = self._latest_from_today(self.get_status)
             return GridStatus(
@@ -589,7 +588,6 @@ class NYISO(ISOBase):
         filename=None,
         verbose=False,
     ):
-
         if filename is None:
             filename = dataset_name
 
@@ -607,7 +605,6 @@ class NYISO(ISOBase):
         if end is None and date > pd.Timestamp.now(
             tz=self.default_timezone,
         ).normalize() - pd.DateOffset(days=7):
-
             if verbose:
                 print(f"Requesting {csv_url}")
 

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -185,10 +185,8 @@ class PJM(ISOBase):
 
     def get_pnode_ids(self):
         data = {
-            "fields": (
-                "effective_date,pnode_id,pnode_name,pnode_subtype,               "
-                " pnode_type,termination_date,voltage_level,zone"
-            ),
+            "fields": "effective_date,pnode_id,pnode_name,pnode_subtype,pnode_type\
+                ,termination_date,voltage_level,zone",
             "termination_date": "12/31/9999exact",
         }
         nodes = self._get_pjm_json("pnode", start=None, params=data)

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -147,7 +147,10 @@ class PJM(ISOBase):
 
         # todo: should we use the UTC field instead of EPT?
         params = {
-            "fields": "evaluated_at_datetime_ept,forecast_area,forecast_datetime_beginning_ept,forecast_load_mw",
+            "fields": (
+                "evaluated_at_datetime_ept,forecast_area,                   "
+                " forecast_datetime_beginning_ept,forecast_load_mw"
+            ),
             "forecast_area": "RTO_COMBINED",
         }
         data = self._get_pjm_json(
@@ -182,7 +185,10 @@ class PJM(ISOBase):
 
     def get_pnode_ids(self):
         data = {
-            "fields": "effective_date,pnode_id,pnode_name,pnode_subtype,pnode_type,termination_date,voltage_level,zone",
+            "fields": (
+                "effective_date,pnode_id,pnode_name,pnode_subtype,               "
+                " pnode_type,termination_date,voltage_level,zone"
+            ),
             "termination_date": "12/31/9999exact",
         }
         nodes = self._get_pjm_json("pnode", start=None, params=data)
@@ -211,25 +217,38 @@ class PJM(ISOBase):
     ):
         """Returns LMP at a previous date
 
-         Notes:
-            * If start date is prior to the PJM archive date, all data must be downloaded before location filtering can be performed due to limitations of PJM API. The archive date is
-              186 days (~6 months) before today for the 5 minute real time market and 731 days (~2 years) before today for the Hourly Real Time and Day Ahead Hourly markets. Node type filter can be
-              performed for Real Time Hourly and Day Ahead Hourly markets.
+        Notes:
+            * If start date is prior to the PJM archive date, all data
+                must be downloaded before location filtering can be performed
+                due to limitations of PJM API. The archive date is
+                186 days (~6 months) before today for the 5 minute real time
+                market and 731 days (~2 years) before today for the Hourly
+                Real Time and Day Ahead Hourly markets. Node type filter can be
+                performed for Real Time Hourly and Day Ahead Hourly markets.
 
-            * If location_type is provided, it is filtered after data is retrieved for Real Time 5 Minute market regardless of the date. This is due to PJM api limitations
+            * If location_type is provided, it is filtered after data
+                is retrieved for Real Time 5 Minute market regardless of the
+                date. This is due to PJM api limitations
 
-         Args:
-             date (str or datetime.date): date to get LMPs for
+        Args:
+            date (str or datetime.date): date to get LMPs for
 
-             end (str or datetime.date): end date to get LMPs for
+            end (str or datetime.date): end date to get LMPs for
 
-             market (str):  Supported Markets: REAL_TIME_5_MIN, REAL_TIME_HOURLY, DAY_AHEAD_HOURLY
+            market (str):  Supported Markets:
+                REAL_TIME_5_MIN, REAL_TIME_HOURLY, DAY_AHEAD_HOURLY
 
-             locations (list, optional):  list of pnodeid to get LMPs for. Defaults to "hubs". Use get_pnode_ids() to get a list of possible pnode ids.
-             If "all", will return data from all p nodes (warning there are over 10,000 unique pnodes, so expect millions or billions of rows!)
+            locations (list, optional):  list of pnodeid to get LMPs for.
+                Defaults to "hubs". Use get_pnode_ids() to get
+                a list of possible pnode ids. If "all", will
+                return data from all p nodes (warning there are
+                over 10,000 unique pnodes, so expect millions or billions of rows!)
 
-             location_type (str, optional):  If specified, will only return data for nodes of this type. Defaults to None. Possible location types are: 'ZONE', 'LOAD', 'GEN', 'AGGREGATE', 'INTERFACE', 'EXT',
-        'HUB', 'EHV', 'TIE', 'RESIDUAL_METERED_EDC'.
+            location_type (str, optional):  If specified,
+                will only return data for nodes of this type.
+                Defaults to None. Possible location types are: 'ZONE',
+                'LOAD', 'GEN', 'AGGREGATE', 'INTERFACE', 'EXT',
+                'HUB', 'EHV', 'TIE', 'RESIDUAL_METERED_EDC'.
 
         """
         market = Markets(market)
@@ -437,7 +456,8 @@ class PJM(ISOBase):
             # drop datetime_beginning_utc
             df = df.drop(columns=["datetime_beginning_utc"])
 
-            # PJM API is inclusive of end, so we need to drop where end timestamp is included
+            # PJM API is inclusive of end,
+            # so we need to drop where end timestamp is included
             df = df[
                 df["Time"].dt.strftime(
                     "%Y-%m-%d %H:%M",

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -6,7 +6,6 @@ import pandas as pd
 import requests
 import tqdm
 
-import gridstatus
 from gridstatus import utils
 from gridstatus.base import FuelMix, ISOBase, Markets, NotSupported
 from gridstatus.decorators import (

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -219,16 +219,16 @@ class PJM(ISOBase):
 
         Notes:
             * If start date is prior to the PJM archive date, all data
-                must be downloaded before location filtering can be performed
-                due to limitations of PJM API. The archive date is
-                186 days (~6 months) before today for the 5 minute real time
-                market and 731 days (~2 years) before today for the Hourly
-                Real Time and Day Ahead Hourly markets. Node type filter can be
-                performed for Real Time Hourly and Day Ahead Hourly markets.
+            must be downloaded before location filtering can be performed
+            due to limitations of PJM API. The archive date is
+            186 days (~6 months) before today for the 5 minute real time
+            market and 731 days (~2 years) before today for the Hourly
+            Real Time and Day Ahead Hourly markets. Node type filter can be
+            performed for Real Time Hourly and Day Ahead Hourly markets.
 
             * If location_type is provided, it is filtered after data
-                is retrieved for Real Time 5 Minute market regardless of the
-                date. This is due to PJM api limitations
+            is retrieved for Real Time 5 Minute market regardless of the
+            date. This is due to PJM api limitations
 
         Args:
             date (str or datetime.date): date to get LMPs for
@@ -236,19 +236,19 @@ class PJM(ISOBase):
             end (str or datetime.date): end date to get LMPs for
 
             market (str):  Supported Markets:
-                REAL_TIME_5_MIN, REAL_TIME_HOURLY, DAY_AHEAD_HOURLY
+            REAL_TIME_5_MIN, REAL_TIME_HOURLY, DAY_AHEAD_HOURLY
 
             locations (list, optional):  list of pnodeid to get LMPs for.
-                Defaults to "hubs". Use get_pnode_ids() to get
-                a list of possible pnode ids. If "all", will
-                return data from all p nodes (warning there are
-                over 10,000 unique pnodes, so expect millions or billions of rows!)
+            Defaults to "hubs". Use get_pnode_ids() to get
+            a list of possible pnode ids. If "all", will
+            return data from all p nodes (warning there are
+            over 10,000 unique pnodes, so expect millions or billions of rows!)
 
             location_type (str, optional):  If specified,
-                will only return data for nodes of this type.
-                Defaults to None. Possible location types are: 'ZONE',
-                'LOAD', 'GEN', 'AGGREGATE', 'INTERFACE', 'EXT',
-                'HUB', 'EHV', 'TIE', 'RESIDUAL_METERED_EDC'.
+            will only return data for nodes of this type.
+            Defaults to None. Possible location types are: 'ZONE',
+            'LOAD', 'GEN', 'AGGREGATE', 'INTERFACE', 'EXT',
+            'HUB', 'EHV', 'TIE', 'RESIDUAL_METERED_EDC'.
 
         """
         market = Markets(market)

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -267,7 +267,10 @@ class PJM(ISOBase):
             market_type = "da"
         else:
             raise ValueError(
-                "market must be one of REAL_TIME_5_MIN, REAL_TIME_HOURLY, DAY_AHEAD_HOURLY",
+                (
+                    "market must be one of REAL_TIME_5_MIN, REAL_TIME_HOURLY,"
+                    " DAY_AHEAD_HOURLY"
+                ),
             )
 
         if location_type:
@@ -279,7 +282,10 @@ class PJM(ISOBase):
 
             if market == Markets.REAL_TIME_5_MIN:
                 warnings.warn(
-                    "When using Real Time 5 Minute market, location_type filter will happen after all data is downloaded",
+                    (
+                        "When using Real Time 5 Minute market, location_type filter"
+                        " will happen after all data is downloaded"
+                    ),
                 )
             else:
                 params["type"] = f"*{location_type}*"
@@ -298,7 +304,10 @@ class PJM(ISOBase):
 
         elif locations is not None:
             warnings.warn(
-                "Querying before archive date, so filtering by location will happen after all data is downloaded",
+                (
+                    "Querying before archive date, so filtering by location will happen"
+                    " after all data is downloaded"
+                ),
             )
 
         data = self._get_pjm_json(
@@ -524,7 +533,6 @@ pnode_id
 
 
 if __name__ == "__main__":
-
     import gridstatus
 
     for i in gridstatus.all_isos:

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -98,8 +98,8 @@ class PJM(ISOBase):
     def get_load(self, date, end=None, verbose=False):
         """Returns load at a previous date at 5 minute intervals
 
-        Args:
-            date (str or datetime.date): date to get load for. must be in last 30 days
+        Arguments:
+            date (datetime.date, str): date to get load for. must be in last 30 days
         """
 
         if date == "latest":
@@ -230,10 +230,10 @@ class PJM(ISOBase):
             is retrieved for Real Time 5 Minute market regardless of the
             date. This is due to PJM api limitations
 
-        Args:
-            date (str or datetime.date): date to get LMPs for
+        Arguments:
+            date (datetime.date, str): date to get LMPs for
 
-            end (str or datetime.date): end date to get LMPs for
+            end (datetime.date, str): end date to get LMPs for
 
             market (str):  Supported Markets:
             REAL_TIME_5_MIN, REAL_TIME_HOURLY, DAY_AHEAD_HOURLY

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -234,19 +234,19 @@ class PJM(ISOBase):
             end (datetime.date, str): end date to get LMPs for
 
             market (str):  Supported Markets:
-            REAL_TIME_5_MIN, REAL_TIME_HOURLY, DAY_AHEAD_HOURLY
+                REAL_TIME_5_MIN, REAL_TIME_HOURLY, DAY_AHEAD_HOURLY
 
             locations (list, optional):  list of pnodeid to get LMPs for.
-            Defaults to "hubs". Use get_pnode_ids() to get
-            a list of possible pnode ids. If "all", will
-            return data from all p nodes (warning there are
-            over 10,000 unique pnodes, so expect millions or billions of rows!)
+                Defaults to "hubs". Use get_pnode_ids() to get
+                a list of possible pnode ids. If "all", will
+                return data from all p nodes (warning there are
+                over 10,000 unique pnodes, so expect millions or billions of rows!)
 
             location_type (str, optional):  If specified,
-            will only return data for nodes of this type.
-            Defaults to None. Possible location types are: 'ZONE',
-            'LOAD', 'GEN', 'AGGREGATE', 'INTERFACE', 'EXT',
-            'HUB', 'EHV', 'TIE', 'RESIDUAL_METERED_EDC'.
+                will only return data for nodes of this type.
+                Defaults to None. Possible location types are: 'ZONE',
+                'LOAD', 'GEN', 'AGGREGATE', 'INTERFACE', 'EXT',
+                'HUB', 'EHV', 'TIE', 'RESIDUAL_METERED_EDC'.
 
         """
         market = Markets(market)

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -342,7 +342,7 @@ class PJM(ISOBase):
             data = data[data["Location Type"] == location_type]
 
         if locations is not None and locations != "ALL":
-            data = gridstatus.utils.filter_lmp_locations(
+            data = utils.filter_lmp_locations(
                 data,
                 map(int, locations),
             )
@@ -369,10 +369,10 @@ class PJM(ISOBase):
         final_params.update(default_params)
 
         if start is not None:
-            start = gridstatus.utils._handle_date(start)
+            start = utils._handle_date(start)
 
             if end:
-                end = gridstatus.utils._handle_date(end)
+                end = utils._handle_date(end)
             else:
                 end = start + pd.DateOffset(days=1)
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -27,8 +27,8 @@ LOCATION_TYPE_HUB = "HUB"
 LOCATION_TYPE_INTERFACE = "INTERFACE"
 LOCATION_TYPE_SETTLEMENT_LOCATION = "SETTLEMENT_LOCATION"
 
-QUERY_RTM5_HUBS_URL = "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/1/query"
-QUERY_RTM5_INTERFACES_URL = "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/2/query"
+QUERY_RTM5_HUBS_URL = "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/1/query"  # noqa
+QUERY_RTM5_INTERFACES_URL = "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/2/query"  # noqa
 
 
 class SPP(ISOBase):
@@ -245,15 +245,16 @@ class SPP(ISOBase):
         queue = pd.read_csv(url, skiprows=1)
 
         queue["Status (Original)"] = queue["Status"]
-
+        completed_val = InterconnectionQueueStatus.COMPLETED.value
+        active_val = InterconnectionQueueStatus.ACTIVE.value
         queue["Status"] = queue["Status"].map(
             {
-                "IA FULLY EXECUTED/COMMERCIAL OPERATION": InterconnectionQueueStatus.COMPLETED.value,
-                "IA FULLY EXECUTED/ON SCHEDULE": InterconnectionQueueStatus.COMPLETED.value,
-                "IA FULLY EXECUTED/ON SUSPENSION": InterconnectionQueueStatus.COMPLETED.value,
-                "IA PENDING": InterconnectionQueueStatus.ACTIVE.value,
-                "DISIS STAGE": InterconnectionQueueStatus.ACTIVE.value,
-                "None": InterconnectionQueueStatus.ACTIVE.value,
+                "IA FULLY EXECUTED/COMMERCIAL OPERATION": completed_val,
+                "IA FULLY EXECUTED/ON SCHEDULE": completed_val,
+                "IA FULLY EXECUTED/ON SUSPENSION": completed_val,
+                "IA PENDING": active_val,
+                "DISIS STAGE": active_val,
+                "None": active_val,
             },
         )
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -160,7 +160,7 @@ class SPP(ISOBase):
         """
 
         type (str): MID_TERM is hourly for next 7 days or
-            SHORT_TERM is every five minutes for a few hours
+        SHORT_TERM is every five minutes for a few hours
         """
         df = self._get_load_and_forecast(verbose=verbose)
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -234,7 +234,7 @@ class SPP(ISOBase):
         """Get interconnection queue
 
         Returns:
-            df (pd.Dataframe): Interconnection queue
+            pandas.DataFrame: Interconnection queue
 
 
         """
@@ -429,12 +429,12 @@ class SPP(ISOBase):
         - Filters by Location
         - Resets the index
 
-        Parameters:
-            df (pd.DataFrame): DataFrame with SPP data
+        Arguments:
+            pandas.DataFrame: DataFrame with SPP data
             market (str): Market
             locations (list): List of locations to filter by
             location_type (str): Location type
-            verbose (bool): Verbose output
+            verbose (bool, optional): Verbose output
         """
 
         df["Market"] = market.value

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -160,9 +160,9 @@ class SPP(ISOBase):
         """Returns load forecast for next 7 days in hourly intervals
 
         Arguments:
-            type (str): MID_TERM is hourly for next 7 days or SHORT_TERM is 
+            type (str): MID_TERM is hourly for next 7 days or SHORT_TERM is
                 every five minutes for a few hours
-        
+
         Returns:
             current_day_forecast (pd.DataFrame): forecast for current day
         """

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -160,7 +160,7 @@ class SPP(ISOBase):
         """Returns load forecast for next 7 days in hourly intervals
 
         Arguments:
-            type (str): MID_TERM is hourly for next 7 days or SHORT_TERM is
+            forecast_type (str): MID_TERM is hourly for next 7 days or SHORT_TERM is
                 every five minutes for a few hours
 
         Returns:

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -327,7 +327,7 @@ class SPP(ISOBase):
             - ``REAL_TIME_5_MIN``
             - ``DAY_AHEAD_HOURLY``
 
-        Supported Location Types: 
+        Supported Location Types:
             - ``hub``
             - ``interface``
             - ``settlement_location``

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -164,7 +164,7 @@ class SPP(ISOBase):
                 every five minutes for a few hours
 
         Returns:
-            current_day_forecast (pd.DataFrame): forecast for current day
+            pd.DataFrame: forecast for current day
         """
         df = self._get_load_and_forecast(verbose=verbose)
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -323,9 +323,14 @@ class SPP(ISOBase):
     ):
         """Get LMP data
 
-        Supported Markets: REAL_TIME_5_MIN, DAY_AHEAD_HOURLY
+        Supported Markets:
+            - ``REAL_TIME_5_MIN``
+            - ``DAY_AHEAD_HOURLY``
 
-        Supported Location Types: "hub", "interface", "settlement_location"
+        Supported Location Types: 
+            - ``hub``
+            - ``interface``
+            - ``settlement_location``
         """
         market = Markets(market)
         if market not in self.markets:

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -27,8 +27,10 @@ LOCATION_TYPE_HUB = "HUB"
 LOCATION_TYPE_INTERFACE = "INTERFACE"
 LOCATION_TYPE_SETTLEMENT_LOCATION = "SETTLEMENT_LOCATION"
 
-QUERY_RTM5_HUBS_URL = "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/1/query"
-QUERY_RTM5_INTERFACES_URL = "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/2/query"
+QUERY_RTM5_HUBS_URL = \
+    "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/1/query"
+QUERY_RTM5_INTERFACES_URL = \
+    "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/2/query"
 
 
 class SPP(ISOBase):
@@ -248,9 +250,12 @@ class SPP(ISOBase):
 
         queue["Status"] = queue["Status"].map(
             {
-                "IA FULLY EXECUTED/COMMERCIAL OPERATION": InterconnectionQueueStatus.COMPLETED.value,
-                "IA FULLY EXECUTED/ON SCHEDULE": InterconnectionQueueStatus.COMPLETED.value,
-                "IA FULLY EXECUTED/ON SUSPENSION": InterconnectionQueueStatus.COMPLETED.value,
+                "IA FULLY EXECUTED/COMMERCIAL OPERATION":
+                    InterconnectionQueueStatus.COMPLETED.value,
+                "IA FULLY EXECUTED/ON SCHEDULE":
+                    InterconnectionQueueStatus.COMPLETED.value,
+                "IA FULLY EXECUTED/ON SUSPENSION":
+                    InterconnectionQueueStatus.COMPLETED.value,
                 "IA PENDING": InterconnectionQueueStatus.ACTIVE.value,
                 "DISIS STAGE": InterconnectionQueueStatus.ACTIVE.value,
                 "None": InterconnectionQueueStatus.ACTIVE.value,

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -27,10 +27,8 @@ LOCATION_TYPE_HUB = "HUB"
 LOCATION_TYPE_INTERFACE = "INTERFACE"
 LOCATION_TYPE_SETTLEMENT_LOCATION = "SETTLEMENT_LOCATION"
 
-QUERY_RTM5_HUBS_URL = \
-    "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/1/query"
-QUERY_RTM5_INTERFACES_URL = \
-    "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/2/query"
+QUERY_RTM5_HUBS_URL = "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/1/query"
+QUERY_RTM5_INTERFACES_URL = "https://pricecontourmap.spp.org/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/2/query"
 
 
 class SPP(ISOBase):
@@ -236,7 +234,7 @@ class SPP(ISOBase):
         """Get interconnection queue
 
         Returns:
-            pd.DataFrame: Interconnection queue
+            df (pd.Dataframe): Interconnection queue
 
 
         """
@@ -250,12 +248,9 @@ class SPP(ISOBase):
 
         queue["Status"] = queue["Status"].map(
             {
-                "IA FULLY EXECUTED/COMMERCIAL OPERATION":
-                    InterconnectionQueueStatus.COMPLETED.value,
-                "IA FULLY EXECUTED/ON SCHEDULE":
-                    InterconnectionQueueStatus.COMPLETED.value,
-                "IA FULLY EXECUTED/ON SUSPENSION":
-                    InterconnectionQueueStatus.COMPLETED.value,
+                "IA FULLY EXECUTED/COMMERCIAL OPERATION": InterconnectionQueueStatus.COMPLETED.value,
+                "IA FULLY EXECUTED/ON SCHEDULE": InterconnectionQueueStatus.COMPLETED.value,
+                "IA FULLY EXECUTED/ON SUSPENSION": InterconnectionQueueStatus.COMPLETED.value,
                 "IA PENDING": InterconnectionQueueStatus.ACTIVE.value,
                 "DISIS STAGE": InterconnectionQueueStatus.ACTIVE.value,
                 "None": InterconnectionQueueStatus.ACTIVE.value,
@@ -434,7 +429,7 @@ class SPP(ISOBase):
         - Resets the index
 
         Parameters:
-            df (DataFrame): DataFrame with SPP data
+            df (pd.DataFrame): DataFrame with SPP data
             market (str): Market
             locations (list): List of locations to filter by
             location_type (str): Location type

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -99,7 +99,8 @@ class SPP(ISOBase):
 
         if (
             status_text
-            == "SPP is currently in Normal Operations with no effective advisories or alerts."
+            == "SPP is currently in Normal Operations with no effective advisories or"
+            " alerts."
         ):
             status = "Normal"
             notes = [status_text]
@@ -116,7 +117,6 @@ class SPP(ISOBase):
         )
 
     def get_fuel_mix(self, date, verbose=False):
-
         if date != "latest":
             raise NotSupported
 
@@ -159,7 +159,8 @@ class SPP(ISOBase):
     def get_load_forecast(self, date, forecast_type="MID_TERM", verbose=False):
         """
 
-        type (str): MID_TERM is hourly for next 7 days or SHORT_TERM is every five minutes for a few hours
+        type (str): MID_TERM is hourly for next 7 days or
+            SHORT_TERM is every five minutes for a few hours
         """
         df = self._get_load_and_forecast(verbose=verbose)
 
@@ -276,7 +277,8 @@ class SPP(ISOBase):
             "Substation or Line": "Interconnection Location",
         }
 
-        # todo: there are a few columns being parsed as "unamed" that aren't being included but should
+        # todo: there are a few columns being parsed
+        # as "unamed" that aren't being included but should
         extra_columns = [
             "In-Service Date",
             "Commercial Operation Date",
@@ -552,7 +554,10 @@ class SPP(ISOBase):
         return df["SETTLEMENT_LOCATION"].unique().tolist()
 
     def _fs_get_rtbm_lmp_by_location_paths(self, date, verbose=False):
-        """Lists files for Real-Time Balancing Market (RTBM), Locational Marginal Price (LMP) by Settlement Location (SL)"""
+        """
+        Lists files for Real-Time Balancing Market (RTBM),
+        Locational Marginal Price (LMP) by Settlement Location (SL)
+        """
         if date == "latest":
             paths = ["/RTBM-LMP-SL-latestInterval.csv"]
         elif utils.is_today(date, self.default_timezone):
@@ -582,7 +587,10 @@ class SPP(ISOBase):
         return pd.concat(all_dfs)
 
     def _fs_get_dam_lmp_by_location_paths(self, date, verbose=False):
-        """Lists files for Day-ahead Market (DAM), Locational Marginal Price (LMP) by Settlement Location (SL)"""
+        """
+        Lists files for Day-ahead Market (DAM),
+        Locational Marginal Price (LMP) by Settlement Location (SL)
+        """
         paths = []
         if date == "latest":
             raise ValueError(

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -157,10 +157,14 @@ class SPP(ISOBase):
             raise NotSupported()
 
     def get_load_forecast(self, date, forecast_type="MID_TERM", verbose=False):
-        """
+        """Returns load forecast for next 7 days in hourly intervals
 
-        type (str): MID_TERM is hourly for next 7 days or
-        SHORT_TERM is every five minutes for a few hours
+        Arguments:
+            type (str): MID_TERM is hourly for next 7 days or SHORT_TERM is 
+                every five minutes for a few hours
+        
+        Returns:
+            current_day_forecast (pd.DataFrame): forecast for current day
         """
         df = self._get_load_and_forecast(verbose=verbose)
 

--- a/gridstatus/tests/test_caiso.py
+++ b/gridstatus/tests/test_caiso.py
@@ -1,5 +1,3 @@
-import pytest
-
 import gridstatus
 
 

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -101,7 +101,6 @@ def test_ercot_get_load_3_days_ago():
 
 
 def test_ercot_get_fuel_mix():
-
     # today
     iso = gridstatus.Ercot()
     cols = [

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -166,7 +166,7 @@ def test_ercot_get_two_days_ago_day_ahead_hourly_zone():
 def test_ercot_get_dam_latest_day_ahead_hourly_zone_should_raise_exception():
     iso = gridstatus.Ercot()
     with pytest.raises(ValueError):
-        df = iso.get_spp(
+        iso.get_spp(
             date="latest",
             market=Markets.DAY_AHEAD_HOURLY,
             location_type="zone",

--- a/gridstatus/tests/test_isone.py
+++ b/gridstatus/tests/test_isone.py
@@ -42,4 +42,8 @@ def test_get_load_forecast(date):
 @pytest.mark.parametrize("market", gridstatus.ISONE().markets)
 def test_get_lmp(date, market):
     iso = gridstatus.ISONE()
-    iso.get_lmp(date=date, market=Markets.DAY_AHEAD_HOURLY, verbose=VERBOSE)
+    iso.get_lmp(
+        date=date,
+        market=Markets.DAY_AHEAD_HOURLY,
+        verbose=VERBOSE,
+    )

--- a/gridstatus/tests/test_isone.py
+++ b/gridstatus/tests/test_isone.py
@@ -12,13 +12,12 @@ def test_isone_fuel_mix():
 
 def run_all(date):
     iso = gridstatus.ISONE()
-
-    data = iso.get_fuel_mix(date=date)
-    data = iso.get_load(date=date)
-    data = iso.get_load_forecast(date=date)
-    data = iso.get_lmp(date=date, market=Markets.DAY_AHEAD_HOURLY)
-    data = iso.get_lmp(date=date, market=Markets.REAL_TIME_5_MIN)
-    data = iso.get_lmp(date=date, market=Markets.REAL_TIME_HOURLY)
+    iso.get_fuel_mix(date=date)
+    iso.get_load(date=date)
+    iso.get_load_forecast(date=date)
+    iso.get_lmp(date=date, market=Markets.DAY_AHEAD_HOURLY)
+    iso.get_lmp(date=date, market=Markets.REAL_TIME_5_MIN)
+    iso.get_lmp(date=date, market=Markets.REAL_TIME_HOURLY)
 
 
 def test_isone_dst_end():

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -3,7 +3,7 @@ import pytest
 from pandas.api.types import is_numeric_dtype
 
 import gridstatus
-from gridstatus import *
+from gridstatus import CAISO, ISONE, MISO, NYISO, PJM, SPP, Ercot, Markets
 from gridstatus.base import FuelMix, GridStatus, ISOBase
 
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
@@ -85,7 +85,7 @@ def test_get_iso():
 
 
 def test_get_iso_invalid():
-    with pytest.raises(Exception) as e_info:
+    with pytest.raises(Exception):
         gridstatus.get_iso("ISO DOESNT EXIST")
 
 
@@ -281,9 +281,7 @@ def test_get_historical_lmp(test):
 def test_get_latest_lmp(test):
     iso = list(test)[0]
     markets = test[iso]["markets"]
-    locations = test[iso]
 
-    date_str = "20220722"
     for m in markets:
         print(iso.iso_id, m)
         latest = iso.get_lmp(date="latest", market=m)
@@ -421,13 +419,13 @@ def test_date_or_start(iso):
     end = pd.Timestamp.now(tz=iso.default_timezone)
     start = end - pd.Timedelta(days=num_days)
 
-    data_date = iso.get_fuel_mix(date=start.date(), end=end.date())
-    data_start = iso.get_fuel_mix(
+    iso.get_fuel_mix(date=start.date(), end=end.date())
+    iso.get_fuel_mix(
         start=start.date(),
         end=end.date(),
     )
-    data_date = iso.get_fuel_mix(date=start.date())
-    data_start = iso.get_fuel_mix(start=start.date())
+    iso.get_fuel_mix(date=start.date())
+    iso.get_fuel_mix(start=start.date())
 
     with pytest.raises(ValueError):
         iso.get_fuel_mix(start=start.date(), date=start.date())

--- a/gridstatus/tests/test_nyiso.py
+++ b/gridstatus/tests/test_nyiso.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 
 import gridstatus
@@ -129,7 +128,7 @@ def test_location_type_parameter():
     assert (df_gen["Location Type"] == "Generator").all()
 
     with pytest.raises(ValueError):
-        df = iso.get_lmp(
+        iso.get_lmp(
             date="latest",
             market=Markets.DAY_AHEAD_HOURLY,
             location_type="dummy",
@@ -166,7 +165,7 @@ def test_nyiso_get_loads():
 
 def test_nyiso_interconnection_queue():
     iso = gridstatus.NYISO()
-    df = iso.get_interconnection_queue()
+    iso.get_interconnection_queue()
 
 
 def test_nyiso_get_capacity_prices():

--- a/gridstatus/tests/test_nyiso.py
+++ b/gridstatus/tests/test_nyiso.py
@@ -171,4 +171,4 @@ def test_nyiso_interconnection_queue():
 def test_nyiso_get_capacity_prices():
     iso = gridstatus.NYISO()
     df = iso.get_capacity_prices(verbose=True)
-    assert not df.empty, "Dataframe came back empty"
+    assert not df.empty, "DataFrame came back empty"

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -1,5 +1,3 @@
-from ftplib import ftpcp
-
 import pandas as pd
 import pytest
 
@@ -30,7 +28,7 @@ def test_no_data():
     date = "2000-01-14"
     iso = gridstatus.PJM()
     with pytest.raises(RuntimeError):
-        df = iso.get_fuel_mix(start=date)
+        iso.get_fuel_mix(start=date)
 
 
 def test_dst_shift_back():

--- a/gridstatus/tests/test_viz.py
+++ b/gridstatus/tests/test_viz.py
@@ -4,7 +4,6 @@ import gridstatus
 
 
 def test_dam_heat_map():
-
     iso = gridstatus.CAISO()
 
     df = iso.get_lmp(
@@ -21,7 +20,8 @@ def test_dam_heat_map():
     assert isinstance(fig, plotly.graph_objs._figure.Figure)
 
     # check if works with hour too
-    # not the best test since we dont know if the viz is actually using it instead of time
+    # not the best test since we dont know if
+    # the viz is actually using it instead of time
     df["Hour"] = df["Time"].dt.hour
     fig = gridstatus.viz.dam_heat_map(df)
     assert isinstance(fig, plotly.graph_objs._figure.Figure)

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -240,7 +240,7 @@ def load_folder(path, time_zone=None, verbose=True):
     Arguments:
         path {str} -- path to folder
         time_zone {str} -- time zone to localize to timestamps.
-            By default returns as UTC
+        By default returns as UTC
 
     Returns:
         pd.DataFrame -- dataframe of all files

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -55,7 +55,6 @@ def make_availability_df():
         for method in methods:
             availability[i.__name__][method] = {}
             for date in ["latest", "today", "historical"]:
-
                 test = date
                 if date == "historical":
                     test = pd.Timestamp.now(
@@ -240,7 +239,8 @@ def load_folder(path, time_zone=None, verbose=True):
 
     Arguments:
         path {str} -- path to folder
-        time_zone {str} -- time zone to localize to timestamps. By default returns as UTC
+        time_zone {str} -- time zone to localize to timestamps.
+            By default returns as UTC
 
     Returns:
         pd.DataFrame -- dataframe of all files

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -164,10 +164,10 @@ def make_lmp_availability_table():
 
 def filter_lmp_locations(df, locations):
     """
-    Filters dataframe by locations, which can be a list, "ALL" or None
+    Filters DataFrame by locations, which can be a list, "ALL" or None
 
-    Parameters:
-        df: pd.DataFrame
+    Arguments:
+        df (pandas.DataFrame): DataFrame to filter
         locations: "ALL" or list of locations to filter "Location" column by
     """
     if locations == "ALL" or locations is None:
@@ -235,7 +235,7 @@ def is_dst_end(date):
 
 
 def load_folder(path, time_zone=None, verbose=True):
-    """Load a single dataframe for same schema csv files in a folder
+    """Load a single DataFrame for same schema csv files in a folder
 
     Arguments:
         path {str} -- path to folder
@@ -243,7 +243,7 @@ def load_folder(path, time_zone=None, verbose=True):
         By default returns as UTC
 
     Returns:
-        pd.DataFrame -- dataframe of all files
+        pandas.DataFrame: A DataFrame of all files
     """
     all_files = glob.glob(os.path.join(path, "*.csv"))
     all_files = sorted(all_files)

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -238,9 +238,10 @@ def load_folder(path, time_zone=None, verbose=True):
     """Load a single DataFrame for same schema csv files in a folder
 
     Arguments:
-        path {str} -- path to folder
-        time_zone {str} -- time zone to localize to timestamps.
-        By default returns as UTC
+        path (str): path to folder
+        time_zone (str): time zone to localize to timestamps.
+            By default returns as UTC
+        verbose (bool, optional): print verbose output. Defaults to True.
 
     Returns:
         pandas.DataFrame: A DataFrame of all files

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -20,7 +20,6 @@ from gridstatus.spp import SPP
 GREEN_CHECKMARK_HTML_ENTITY = "&#x2705;"
 
 RED_X_HTML_ENTITY = "&#10060;"
-
 all_isos = [MISO, CAISO, PJM, Ercot, SPP, NYISO, ISONE]
 
 

--- a/gridstatus/viz.py
+++ b/gridstatus/viz.py
@@ -6,7 +6,8 @@ def dam_heat_map(df):
 
     Args:
         df (pd.DataFrame): A DataFrame with columns "Time", "Location", and "LMP".
-        If Hour is specified, it will be used as the x-axis. Otherwise, the hour ending will be used instead of Time
+            If Hour is specified, it will be used as the x-axis.
+            Otherwise, the hour ending will be used instead of Time
 
 
     Returns:

--- a/gridstatus/viz.py
+++ b/gridstatus/viz.py
@@ -6,8 +6,8 @@ def dam_heat_map(df):
 
     Args:
         df (pd.DataFrame): A DataFrame with columns "Time", "Location", and "LMP".
-            If Hour is specified, it will be used as the x-axis.
-            Otherwise, the hour ending will be used instead of Time
+        If Hour is specified, it will be used as the x-axis.
+        Otherwise, the hour ending will be used instead of Time
 
 
     Returns:

--- a/gridstatus/viz.py
+++ b/gridstatus/viz.py
@@ -4,10 +4,10 @@ import plotly.express as px
 def dam_heat_map(df):
     """Create a heat map of day-ahead location marginal prices.
 
-    Args:
-        df (pd.DataFrame): A DataFrame with columns "Time", "Location", and "LMP".
-        If Hour is specified, it will be used as the x-axis.
-        Otherwise, the hour ending will be used instead of Time
+    Arguments:
+        df (pandas.DataFrame): A DataFrame with columns "Time", "Location", and "LMP".
+            If Hour is specified, it will be used as the x-axis.
+            Otherwise, the hour ending will be used instead of Time
 
 
     Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,4 +117,5 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
+# Never enforce `E501` (line length violations), lines cannot be > 79 chars
 ignore = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,6 @@ src = ["gridstatus"]
 
 [tool.ruff.isort]
 known-first-party = ["gridstatus"]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["E402", "F401", "I001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ markers = [
 ]
 
 [tool.black]
+line-length = 88
 target-version = ['py311']
 
 [build-system]
@@ -109,8 +110,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-# Never enforce `E501` (line length violations), lines cannot be > 79 chars
-ignore = ["E501"]
+line-length = 88
+ignore = []
 select = [
     # Pyflakes
     "F",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,8 @@ select = [
     # Pycodestyle
     "E",
     "W",
+    # flake8-quotes
+    "Q",
     # isort
     "I001"
 ]
@@ -126,4 +128,4 @@ src = ["gridstatus"]
 known-first-party = ["gridstatus"]
 
 [tool.ruff.per-file-ignores]
-"__init__.py" = ["E402", "F401", "I001"]
+"__init__.py" = ["F401", "E402", "F403", "F405", "E501", "I001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ test = [
 ]
 dev = [
     "ruff == 0.0.202",
-    "isort == 5.10.1",
     "black[jupyter] == 22.12.0",
     "pre-commit == 2.21.0",
 ]
@@ -99,13 +98,6 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 
-[tool.isort]
-profile = "black"
-forced_separate = "gridstatus"
-known_first_party = "gridstatus"
-skip = "__init__.py"
-multi_line_output = 3
-
 [tool.black]
 target-version = ['py311']
 
@@ -119,3 +111,16 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 # Never enforce `E501` (line length violations), lines cannot be > 79 chars
 ignore = ["E501"]
+select = [
+    # Pyflakes
+    "F",
+    # Pycodestyle
+    "E",
+    "W",
+    # isort
+    "I001"
+]
+src = ["gridstatus"]
+
+[tool.ruff.isort]
+known-first-party = ["gridstatus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,4 +117,4 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-ignore = ["E501", "F405"]
+ignore = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ test = [
     "pytest-rerunfailures == 10.3",
 ]
 dev = [
-    "flake8 == 5.0.4",
+    "ruff == 0.0.202",
     "isort == 5.10.1",
     "black[jupyter] == 22.12.0",
     "pre-commit == 2.21.0",
@@ -115,3 +115,6 @@ requires = [
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+ignore = ["E501", "F405"]


### PR DESCRIPTION
- Added [ruff](https://github.com/charliermarsh/ruff) for running linting
- Added **ruff** commands to Makefile
- Added **ruff** to pre-commit
- Removed variables in unit tests that were unused (maybe some of these should be asserted?)
- Removed **flake8** as dev dependency, since **ruff** does this, but faster
- Remove **isort** as dev dependency, since **ruff** has the [same function](https://github.com/charliermarsh/ruff#how-does-ruffs-import-sorting-compare-to-isort), but faster