### PR TITLE
ISONE: _make_request improvements

### DIFF
--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -554,13 +554,14 @@ class ISONE(ISOBase):
 
 def _make_request(url, skiprows, verbose):
     with requests.Session() as s:
+        # make first get request to get cookies set
+        s.get(
+            "https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/gen-fuel-mix",
+        )
+
         # in testing, never takes more than 2 attempts
         attempt = 0
         while attempt < 3:
-            # make first get request to get cookies set
-            r1 = s.get(
-                "https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/gen-fuel-mix",
-            )
             if verbose:
                 print("Loading data from {}".format(url))
 

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -1,6 +1,7 @@
 import io
 import math
 import re
+import sys
 from heapq import merge
 from tabnanny import verbose
 
@@ -563,7 +564,7 @@ def _make_request(url, skiprows, verbose):
         attempt = 0
         while attempt < 3:
             if verbose:
-                print("Loading data from {}".format(url))
+                print(f"Loading data from {url}", file=sys.stderr)
 
             r2 = s.get(url)
             r2_content_type = r2.headers["Content-Type"]
@@ -571,14 +572,12 @@ def _make_request(url, skiprows, verbose):
             if r2.status_code == 200 and r2_content_type == "text/csv":
                 break
 
-            print("Attempt {} failed. Retrying...".format(attempt + 1))
+            print(f"Attempt {attempt+1} failed. Retrying...", file=sys.stderr)
             attempt += 1
 
         if r2.status_code != 200 or r2_content_type != "text/csv":
             raise RuntimeError(
-                "Failed to get data from {}. Check if ISONE is down and try again later".format(
-                    url,
-                ),
+                f"Failed to get data from {url}. Check if ISONE is down and try again later",
             )
 
         df = pd.read_csv(

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -566,22 +566,22 @@ def _make_request(url, skiprows, verbose):
             if verbose:
                 print(f"Loading data from {url}", file=sys.stderr)
 
-            r2 = s.get(url)
-            r2_content_type = r2.headers["Content-Type"]
+            response = s.get(url)
+            content_type = response.headers["Content-Type"]
 
-            if r2.status_code == 200 and r2_content_type == "text/csv":
+            if response.status_code == 200 and content_type == "text/csv":
                 break
 
             print(f"Attempt {attempt+1} failed. Retrying...", file=sys.stderr)
             attempt += 1
 
-        if r2.status_code != 200 or r2_content_type != "text/csv":
+        if response.status_code != 200 or content_type != "text/csv":
             raise RuntimeError(
                 f"Failed to get data from {url}. Check if ISONE is down and try again later",
             )
 
         df = pd.read_csv(
-            io.StringIO(r2.content.decode("utf8")),
+            io.StringIO(response.content.decode("utf8")),
             skiprows=skiprows,
             skipfooter=1,
             engine="python",

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -561,19 +561,19 @@ def _make_request(url, skiprows, verbose):
             r1 = s.get(
                 "https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/gen-fuel-mix",
             )
-
             if verbose:
                 print("Loading data from {}".format(url))
 
             r2 = s.get(url)
+            r2_content_type = r2.headers["Content-Type"]
 
-            if r2.status_code == 200:
+            if r2.status_code == 200 and r2_content_type == "text/csv":
                 break
 
             print("Attempt {} failed. Retrying...".format(attempt + 1))
             attempt += 1
 
-        if r2.status_code != 200:
+        if r2.status_code != 200 or r2_content_type != "text/csv":
             raise RuntimeError(
                 "Failed to get data from {}. Check if ISONE is down and try again later".format(
                     url,


### PR DESCRIPTION
Quality-of-life improvements for ISONE's `_make_request`:

* Initial fetch for setting cookies runs before reattempt loop
* Check for `text/csv` Content-Type to avoid status code 200 `text/html` false positives
* Use f-strings, send to stderr where reasonable