### PR TITLE
Fix CAISO Market Naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Update CAISO LMP markets to support real time five minute
 
+    ### Breaking Changes
+
+    The following changes were made to CAISO Market:
+
+    - `REAL_TIME_15_MIN` now maps to the FMM market (previously was HASP which is now removed)
+    - `REAL_TIME_5_MIN` now maps to the RTD market
+    - `DAY_AHEAD_HOURLY` unchanged
+
+
 ## v0.17.0 - Dec 30, 2022
 
 - Add CAISO LMP Heat Map Example Notebook

--- a/docs/lmp.md
+++ b/docs/lmp.md
@@ -13,7 +13,7 @@ Below are the currently supported LMP markets
 <!-- LMP AVAILABILITY TABLE START -->
 |       | Method    | REAL_TIME_5_MIN   | REAL_TIME_15_MIN   | REAL_TIME_HOURLY   | DAY_AHEAD_HOURLY   |
 |:------|:----------|:------------------|:-------------------|:-------------------|:-------------------|
-| CAISO | `get_lmp` | &#x2705;          | &#10060;           | &#x2705;           | &#x2705;           |
+| CAISO | `get_lmp` | &#x2705;          | &#x2705;           | &#10060;           | &#x2705;           |
 | Ercot | `get_spp` | &#10060;          | &#x2705;           | &#10060;           | &#x2705;           |
 | ISONE | `get_lmp` | &#x2705;          | &#10060;           | &#x2705;           | &#x2705;           |
 | MISO  | `get_lmp` | &#x2705;          | &#10060;           | &#10060;           | &#x2705;           |

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -28,7 +28,7 @@ class CAISO(ISOBase):
     # Markets PRC_INTVL_LMP, PRC_RTPD_LMP, PRC_LMP
     markets = [
         Markets.REAL_TIME_5_MIN,
-        Markets.REAL_TIME_HOURLY,
+        Markets.REAL_TIME_15_MIN,
         Markets.DAY_AHEAD_HOURLY,
     ]
 
@@ -239,7 +239,7 @@ class CAISO(ISOBase):
             market_run_id = "DAM"
             version = 12
             PRICE_COL = "MW"
-        elif market == Markets.REAL_TIME_HOURLY:
+        elif market == Markets.REAL_TIME_15_MIN:
             query_name = "PRC_RTPD_LMP"
             market_run_id = "RTPD"
             version = 3

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -248,7 +248,7 @@ def test_get_historical_lmp(test):
         {
             CAISO(): {
                 "markets": [
-                    Markets.REAL_TIME_HOURLY,
+                    Markets.REAL_TIME_15_MIN,
                     Markets.DAY_AHEAD_HOURLY,
                     Markets.REAL_TIME_5_MIN,
                 ],
@@ -296,7 +296,7 @@ def test_get_latest_lmp(test):
             CAISO(): {
                 "markets": [
                     Markets.REAL_TIME_5_MIN,
-                    Markets.REAL_TIME_HOURLY,
+                    Markets.REAL_TIME_15_MIN,
                     Markets.DAY_AHEAD_HOURLY,
                 ],
             },

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -202,7 +202,7 @@ def test_get_historical_load(iso):
         {
             CAISO(): {
                 "markets": [
-                    Markets.REAL_TIME_HOURLY,
+                    Markets.REAL_TIME_15_MIN,
                     Markets.DAY_AHEAD_HOURLY,
                     Markets.REAL_TIME_5_MIN,
                 ],


### PR DESCRIPTION
Fixes market naming mistake in #117 where the RT 15 minute market was called the RT Hourly
