### PR TITLE
Refactor Test Part I

### DIFF
--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -69,6 +69,11 @@ class BaseTestISO:
             assert isinstance(df, pd.DataFrame)
             self._check_lmp_columns(df, market)
 
+    def test_get_load_forecast_historical(self):
+        test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
+        forecast = self.iso.get_load_forecast(date=test_date)
+        self._check_forecast(forecast)
+
     def test_get_load_historical(self):
         # pick a test date 2 weeks back
         test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
@@ -114,6 +119,19 @@ class BaseTestISO:
 
         # ensure there is a homepage if gridstatus can retrieve a status
         assert isinstance(self.iso.status_homepage, str)
+
+    def _check_forecast(self, df):
+        assert set(df.columns) == set(
+            ["Forecast Time", "Time", "Load Forecast"],
+        )
+
+        assert self._check_is_datetime_type(df["Forecast Time"])
+        assert self._check_is_datetime_type(df["Time"])
+
+    def _check_is_datetime_type(self, series):
+        return pd.core.dtypes.common.is_datetime64_ns_dtype(
+            series,
+        ) | pd.core.dtypes.common.is_timedelta64_ns_dtype(series)
 
     @staticmethod
     def _check_lmp_columns(df, market):

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -47,6 +47,14 @@ class BaseTestISO:
         df = self.iso.get_fuel_mix("today")
         assert isinstance(df, pd.DataFrame)
 
+    # @pytest.mark.parametrize in ISO
+    def test_get_lmp_historical(self, market=None):
+        date_str = "20220722"
+        if market is not None:
+            hist = self.iso.get_lmp(date_str, market=market)
+            assert isinstance(hist, pd.DataFrame)
+            self._check_lmp_columns(hist, market)
+
     def test_get_load_historical(self):
         # pick a test date 2 weeks back
         test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
@@ -92,3 +100,19 @@ class BaseTestISO:
 
         # ensure there is a homepage if gridstatus can retrieve a status
         assert isinstance(self.iso.status_homepage, str)
+
+    @staticmethod
+    def _check_lmp_columns(df, market):
+        assert set(
+            [
+                "Time",
+                "Market",
+                "Location",
+                "Location Type",
+                "LMP",
+                "Energy",
+                "Congestion",
+                "Loss",
+            ],
+        ).issubset(df.columns)
+        assert df["Market"].unique()[0] == market.value

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -55,6 +55,13 @@ class BaseTestISO:
             assert isinstance(hist, pd.DataFrame)
             self._check_lmp_columns(hist, market)
 
+    # @pytest.mark.parametrize in ISO
+    def test_get_lmp_latest(self, market=None):
+        if market is not None:
+            df = self.iso.get_lmp("latest", market=market)
+            assert isinstance(df, pd.DataFrame)
+            self._check_lmp_columns(df, market)
+
     def test_get_load_historical(self):
         # pick a test date 2 weeks back
         test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from gridstatus.base import FuelMix
+from gridstatus.base import FuelMix, GridStatus
 
 
 class BaseTestISO:
@@ -23,3 +23,10 @@ class BaseTestISO:
     def test_get_fuel_mix_today(self):
         df = self.iso.get_fuel_mix("today")
         assert isinstance(df, pd.DataFrame)
+
+    def test_get_status_latest(self):
+        status = self.iso.get_status("latest")
+        assert isinstance(status, GridStatus)
+
+        # ensure there is a homepage if gridstatus can retrieve a status
+        assert isinstance(self.iso.status_homepage, str)

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -47,6 +47,32 @@ class BaseTestISO:
         df = self.iso.get_fuel_mix("today")
         assert isinstance(df, pd.DataFrame)
 
+    def test_get_load_historical(self):
+        # pick a test date 2 weeks back
+        test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
+
+        # date string works
+        date_str = test_date.strftime("%Y%m%d")
+        df = self.iso.get_load(date_str)
+        assert isinstance(df, pd.DataFrame)
+        assert set(["Time", "Load"]) == set(df.columns)
+        assert df.loc[0]["Time"].strftime("%Y%m%d") == date_str
+        assert is_numeric_dtype(df["Load"])
+
+        # timestamp object works
+        df = self.iso.get_load(test_date)
+        assert isinstance(df, pd.DataFrame)
+        assert set(["Time", "Load"]) == set(df.columns)
+        assert df.loc[0]["Time"].strftime("%Y%m%d") == test_date.strftime("%Y%m%d")
+        assert is_numeric_dtype(df["Load"])
+
+        # datetime object works
+        df = self.iso.get_load(test_date)
+        assert isinstance(df, pd.DataFrame)
+        assert set(["Time", "Load"]) == set(df.columns)
+        assert df.loc[0]["Time"].strftime("%Y%m%d") == test_date.strftime("%Y%m%d")
+        assert is_numeric_dtype(df["Load"])
+
     def test_get_load_latest(self):
         load = self.iso.get_load("latest")
         set(["time", "load"]) == load.keys()

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -62,6 +62,13 @@ class BaseTestISO:
             assert isinstance(df, pd.DataFrame)
             self._check_lmp_columns(df, market)
 
+    # @pytest.mark.parametrize in ISO
+    def test_get_lmp_today(self, market=None):
+        if market is not None:
+            df = self.iso.get_lmp("today", market=market)
+            assert isinstance(df, pd.DataFrame)
+            self._check_lmp_columns(df, market)
+
     def test_get_load_historical(self):
         # pick a test date 2 weeks back
         test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -74,6 +74,15 @@ class BaseTestISO:
         forecast = self.iso.get_load_forecast(date=test_date)
         self._check_forecast(forecast)
 
+    def test_get_load_forecast_historical_with_date_range(self):
+        end = pd.Timestamp.now().normalize() - pd.Timedelta(days=14)
+        start = (end - pd.Timedelta(days=7)).date()
+        forecast = self.iso.get_load_forecast(
+            start,
+            end=end,
+        )
+        self._check_forecast(forecast)
+
     def test_get_load_historical(self):
         # pick a test date 2 weeks back
         test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -19,3 +19,7 @@ class BaseTestISO:
         assert len(mix.mix) > 0
         assert mix.iso == self.iso.name
         assert isinstance(repr(mix), str)
+
+    def test_get_fuel_mix_today(self):
+        df = self.iso.get_fuel_mix("today")
+        assert isinstance(df, pd.DataFrame)

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 from pandas.core.dtypes.common import is_numeric_dtype
 
 from gridstatus.base import FuelMix, GridStatus
@@ -10,6 +11,22 @@ class BaseTestISO:
 
     def test_init(self):
         assert self.iso is not None
+
+    def test_get_fuel_mix_date_or_start(self):
+        num_days = 2
+        end = pd.Timestamp.now(tz=self.iso.default_timezone)
+        start = end - pd.Timedelta(days=num_days)
+
+        self.iso.get_fuel_mix(date=start.date(), end=end.date())
+        self.iso.get_fuel_mix(
+            start=start.date(),
+            end=end.date(),
+        )
+        self.iso.get_fuel_mix(date=start.date())
+        self.iso.get_fuel_mix(start=start.date())
+
+        with pytest.raises(ValueError):
+            self.iso.get_fuel_mix(start=start.date(), date=start.date())
 
     def test_get_fuel_mix_historical(self):
         # date string works

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -143,6 +143,10 @@ class BaseTestISO:
         # ensure there is a homepage if gridstatus can retrieve a status
         assert isinstance(self.iso.status_homepage, str)
 
+    def test_get_storage_today(self):
+        storage = self.iso.get_storage("today")
+        self._check_storage(storage)
+
     def _check_forecast(self, df):
         assert set(df.columns) == set(
             ["Forecast Time", "Time", "Load Forecast"],
@@ -171,3 +175,8 @@ class BaseTestISO:
             ],
         ).issubset(df.columns)
         assert df["Market"].unique()[0] == market.value
+
+    def _check_storage(self, df):
+        assert set(df.columns) == set(
+            ["Time", "Supply", "Type"],
+        )

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -143,6 +143,11 @@ class BaseTestISO:
         # ensure there is a homepage if gridstatus can retrieve a status
         assert isinstance(self.iso.status_homepage, str)
 
+    def test_get_storage_historical(self):
+        test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
+        storage = self.iso.get_storage(date=test_date)
+        self._check_storage(storage)
+
     def test_get_storage_today(self):
         storage = self.iso.get_storage("today")
         self._check_storage(storage)

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -33,6 +33,16 @@ class BaseTestISO:
         assert df.loc[0]["Time"].strftime("%Y%m%d") == date_obj.strftime("%Y%m%d")
         assert df.loc[0]["Time"].tz is not None
 
+    def test_get_fuel_mix_historical_with_date_range(self):
+        # range not inclusive, add one to include today
+        num_days = 7
+        end = pd.Timestamp.now(tz=self.iso.default_timezone) + pd.Timedelta(days=1)
+        start = end - pd.Timedelta(days=num_days)
+
+        data = self.iso.get_fuel_mix(date=start.date(), end=end.date())
+        # make sure right number of days are returned
+        assert data["Time"].dt.day.nunique() == num_days
+
     def test_get_fuel_mix_latest(self):
         mix = self.iso.get_fuel_mix("latest")
         assert isinstance(mix, FuelMix)

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -83,6 +83,10 @@ class BaseTestISO:
         )
         self._check_forecast(forecast)
 
+    def test_get_load_forecast_today(self):
+        forecast = self.iso.get_load_forecast("today")
+        self._check_forecast(forecast)
+
     def test_get_load_historical(self):
         # pick a test date 2 weeks back
         test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -10,6 +10,28 @@ class BaseTestISO:
     def test_init(self):
         assert self.iso is not None
 
+    def test_get_fuel_mix_historical(self):
+        # date string works
+        date_str = "04/03/2022"
+        df = self.iso.get_fuel_mix(date_str)
+        assert isinstance(df, pd.DataFrame)
+        assert df.loc[0]["Time"].strftime("%m/%d/%Y") == date_str
+        assert df.loc[0]["Time"].tz is not None
+
+        # timestamp object works
+        date_obj = pd.to_datetime("2019/11/19")
+        df = self.iso.get_fuel_mix(date_obj)
+        assert isinstance(df, pd.DataFrame)
+        assert df.loc[0]["Time"].strftime("%Y%m%d") == date_obj.strftime("%Y%m%d")
+        assert df.loc[0]["Time"].tz is not None
+
+        # datetime object works
+        date_obj = pd.to_datetime("2021/05/09").date()
+        df = self.iso.get_fuel_mix(date_obj)
+        assert isinstance(df, pd.DataFrame)
+        assert df.loc[0]["Time"].strftime("%Y%m%d") == date_obj.strftime("%Y%m%d")
+        assert df.loc[0]["Time"].tz is not None
+
     def test_get_fuel_mix_latest(self):
         mix = self.iso.get_fuel_mix("latest")
         assert isinstance(mix, FuelMix)

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -1,0 +1,3 @@
+class BaseTestISO:
+    def test_init(self):
+        assert self.iso is not None

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -79,6 +79,14 @@ class BaseTestISO:
             assert isinstance(df, pd.DataFrame)
             self._check_lmp_columns(df, market)
 
+    def test_get_load_historical_with_date_range(self):
+        num_days = 7
+        end = pd.Timestamp.now(tz=self.iso.default_timezone) + pd.Timedelta(days=1)
+        start = end - pd.Timedelta(days=num_days)
+        data = self.iso.get_load(date=start.date(), end=end.date())
+        # make sure right number of days are returned
+        assert data["Time"].dt.day.nunique() == num_days
+
     def test_get_load_forecast_historical(self):
         test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
         forecast = self.iso.get_load_forecast(date=test_date)

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -47,6 +47,11 @@ class BaseTestISO:
         df = self.iso.get_fuel_mix("today")
         assert isinstance(df, pd.DataFrame)
 
+    def test_get_load_latest(self):
+        load = self.iso.get_load("latest")
+        set(["time", "load"]) == load.keys()
+        assert is_numeric_dtype(type(load["load"]))
+
     def test_get_load_today(self):
         df = self.iso.get_load("today")
         assert isinstance(df, pd.DataFrame)

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -1,3 +1,21 @@
+import pandas as pd
+
+from gridstatus.base import FuelMix
+
+
 class BaseTestISO:
+
+    iso = None
+
     def test_init(self):
         assert self.iso is not None
+
+    def test_get_fuel_mix_latest(self):
+        mix = self.iso.get_fuel_mix("latest")
+        assert isinstance(mix, FuelMix)
+        assert isinstance(mix.time, pd.Timestamp)
+        assert isinstance(mix.mix, pd.DataFrame)
+        assert repr(mix)
+        assert len(mix.mix) > 0
+        assert mix.iso == self.iso.name
+        assert isinstance(repr(mix), str)

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pandas.core.dtypes.common import is_numeric_dtype
 
 from gridstatus.base import FuelMix, GridStatus
 
@@ -45,6 +46,14 @@ class BaseTestISO:
     def test_get_fuel_mix_today(self):
         df = self.iso.get_fuel_mix("today")
         assert isinstance(df, pd.DataFrame)
+
+    def test_get_load_today(self):
+        df = self.iso.get_load("today")
+        assert isinstance(df, pd.DataFrame)
+        assert ["Time", "Load"] == df.columns.tolist()
+        assert is_numeric_dtype(df["Load"])
+        assert isinstance(df.loc[0]["Time"], pd.Timestamp)
+        assert df.loc[0]["Time"].tz is not None
 
     def test_get_status_latest(self):
         status = self.iso.get_status("latest")

--- a/gridstatus/tests/decorators.py
+++ b/gridstatus/tests/decorators.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+class with_markets:
+    def __init__(self, *markets):
+        self.markets = markets
+
+    def __call__(self, *args, **kwargs):
+        return pytest.mark.parametrize("market", self.markets)(*args, **kwargs)

--- a/gridstatus/tests/test_caiso2.py
+++ b/gridstatus/tests/test_caiso2.py
@@ -10,21 +10,24 @@ class TestCAISO(BaseTestISO):
 
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
-        Markets.REAL_TIME_HOURLY,
+        Markets.REAL_TIME_15_MIN,
+        Markets.REAL_TIME_5_MIN,
     )
     def test_get_lmp_historical(self, market):
         super().test_get_lmp_historical(market=market)
 
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
-        Markets.REAL_TIME_HOURLY,
+        Markets.REAL_TIME_15_MIN,
+        Markets.REAL_TIME_5_MIN,
     )
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market=market)
 
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
-        Markets.REAL_TIME_HOURLY,
+        Markets.REAL_TIME_15_MIN,
+        Markets.REAL_TIME_5_MIN,
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)

--- a/gridstatus/tests/test_caiso2.py
+++ b/gridstatus/tests/test_caiso2.py
@@ -1,6 +1,19 @@
-from gridstatus import CAISO
+import pytest
+
+from gridstatus import CAISO, Markets
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
 class TestCAISO(BaseTestISO):
     iso = CAISO()
+
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.DAY_AHEAD_HOURLY,
+            Markets.REAL_TIME_15_MIN,
+            Markets.REAL_TIME_HOURLY,
+        ],
+    )
+    def test_get_lmp_historical(self, market):
+        super().test_get_lmp_historical(market=market)

--- a/gridstatus/tests/test_caiso2.py
+++ b/gridstatus/tests/test_caiso2.py
@@ -17,3 +17,14 @@ class TestCAISO(BaseTestISO):
     )
     def test_get_lmp_historical(self, market):
         super().test_get_lmp_historical(market=market)
+
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.DAY_AHEAD_HOURLY,
+            Markets.REAL_TIME_15_MIN,
+            Markets.REAL_TIME_HOURLY,
+        ],
+    )
+    def test_get_lmp_latest(self, market):
+        super().test_get_lmp_latest(market=market)

--- a/gridstatus/tests/test_caiso2.py
+++ b/gridstatus/tests/test_caiso2.py
@@ -1,41 +1,31 @@
-import pytest
-
 from gridstatus import CAISO, Markets
 from gridstatus.tests.base_test_iso import BaseTestISO
+from gridstatus.tests.decorators import with_markets
 
 
 class TestCAISO(BaseTestISO):
     iso = CAISO()
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.DAY_AHEAD_HOURLY,
-            Markets.REAL_TIME_15_MIN,
-            Markets.REAL_TIME_HOURLY,
-        ],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
+        Markets.REAL_TIME_15_MIN,
+        Markets.REAL_TIME_HOURLY,
     )
     def test_get_lmp_historical(self, market):
         super().test_get_lmp_historical(market=market)
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.DAY_AHEAD_HOURLY,
-            Markets.REAL_TIME_15_MIN,
-            Markets.REAL_TIME_HOURLY,
-        ],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
+        Markets.REAL_TIME_15_MIN,
+        Markets.REAL_TIME_HOURLY,
     )
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market=market)
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.DAY_AHEAD_HOURLY,
-            Markets.REAL_TIME_15_MIN,
-            Markets.REAL_TIME_HOURLY,
-        ],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
+        Markets.REAL_TIME_15_MIN,
+        Markets.REAL_TIME_HOURLY,
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)

--- a/gridstatus/tests/test_caiso2.py
+++ b/gridstatus/tests/test_caiso2.py
@@ -6,6 +6,8 @@ from gridstatus.tests.decorators import with_markets
 class TestCAISO(BaseTestISO):
     iso = CAISO()
 
+    """get_lmp"""
+
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
         Markets.REAL_TIME_HOURLY,

--- a/gridstatus/tests/test_caiso2.py
+++ b/gridstatus/tests/test_caiso2.py
@@ -28,3 +28,14 @@ class TestCAISO(BaseTestISO):
     )
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market=market)
+
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.DAY_AHEAD_HOURLY,
+            Markets.REAL_TIME_15_MIN,
+            Markets.REAL_TIME_HOURLY,
+        ],
+    )
+    def test_get_lmp_today(self, market):
+        super().test_get_lmp_today(market=market)

--- a/gridstatus/tests/test_caiso2.py
+++ b/gridstatus/tests/test_caiso2.py
@@ -1,0 +1,6 @@
+from gridstatus import CAISO
+from gridstatus.tests.base_test_iso import BaseTestISO
+
+
+class TestCAISO(BaseTestISO):
+    iso = CAISO()

--- a/gridstatus/tests/test_caiso2.py
+++ b/gridstatus/tests/test_caiso2.py
@@ -8,7 +8,6 @@ class TestCAISO(BaseTestISO):
 
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
-        Markets.REAL_TIME_15_MIN,
         Markets.REAL_TIME_HOURLY,
     )
     def test_get_lmp_historical(self, market):
@@ -16,7 +15,6 @@ class TestCAISO(BaseTestISO):
 
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
-        Markets.REAL_TIME_15_MIN,
         Markets.REAL_TIME_HOURLY,
     )
     def test_get_lmp_latest(self, market):
@@ -24,7 +22,6 @@ class TestCAISO(BaseTestISO):
 
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
-        Markets.REAL_TIME_15_MIN,
         Markets.REAL_TIME_HOURLY,
     )
     def test_get_lmp_today(self, market):

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -17,3 +17,6 @@ class TestErcot(BaseTestISO):
     def test_get_load_forecast_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
+
+    def test_get_load_forecast_historical_with_date_range(self):
+        pass

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -7,6 +7,7 @@ from gridstatus.tests.base_test_iso import BaseTestISO
 class TestErcot(BaseTestISO):
     iso = Ercot()
 
+    @pytest.mark.skip
     def test_get_fuel_mix_date_or_start(self):
         pass
 
@@ -14,9 +15,11 @@ class TestErcot(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
 
+    @pytest.mark.skip
     def test_get_fuel_mix_historical_with_date_range(self):
         pass
 
+    @pytest.mark.skip
     def test_get_lmp_historical(self, markets=None):
         pass
 
@@ -24,6 +27,7 @@ class TestErcot(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
 
+    @pytest.mark.skip
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -7,6 +7,9 @@ from gridstatus.tests.base_test_iso import BaseTestISO
 class TestErcot(BaseTestISO):
     iso = Ercot()
 
+    def test_get_fuel_mix_date_or_start(self):
+        pass
+
     def test_get_fuel_mix_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -1,6 +1,12 @@
-from gridstatus import Ercot
+import pytest
+
+from gridstatus import Ercot, NotSupported
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
 class TestErcot(BaseTestISO):
     iso = Ercot()
+
+    def test_get_fuel_mix_historical(self):
+        with pytest.raises(NotSupported):
+            super().test_get_fuel_mix_historical()

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -13,3 +13,7 @@ class TestErcot(BaseTestISO):
 
     def test_get_lmp_historical(self, markets=None):
         pass
+
+    def test_get_load_forecast_historical(self):
+        with pytest.raises(NotSupported):
+            super().test_get_load_forecast_historical()

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -10,3 +10,6 @@ class TestErcot(BaseTestISO):
     def test_get_fuel_mix_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
+
+    def test_get_lmp_historical(self, markets=None):
+        pass

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -1,0 +1,6 @@
+from gridstatus import Ercot
+from gridstatus.tests.base_test_iso import BaseTestISO
+
+
+class TestErcot(BaseTestISO):
+    iso = Ercot()

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -9,7 +9,7 @@ class TestErcot(BaseTestISO):
 
     """get_fuel_mix"""
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_fuel_mix_date_or_start(self):
         pass
 
@@ -17,13 +17,13 @@ class TestErcot(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_fuel_mix_historical_with_date_range(self):
         pass
 
     """get_lmp"""
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_lmp_historical(self, markets=None):
         pass
 
@@ -33,7 +33,7 @@ class TestErcot(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -11,6 +11,9 @@ class TestErcot(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
 
+    def test_get_fuel_mix_historical_with_date_range(self):
+        pass
+
     def test_get_lmp_historical(self, markets=None):
         pass
 

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -24,6 +24,10 @@ class TestErcot(BaseTestISO):
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 
+    def test_get_storage_historical(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_historical()
+
     def test_get_storage_today(self):
         with pytest.raises(NotImplementedError):
             super().test_get_storage_today()

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -23,3 +23,7 @@ class TestErcot(BaseTestISO):
 
     def test_get_load_forecast_historical_with_date_range(self):
         pass
+
+    def test_get_storage_today(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_today()

--- a/gridstatus/tests/test_ercot2.py
+++ b/gridstatus/tests/test_ercot2.py
@@ -7,6 +7,8 @@ from gridstatus.tests.base_test_iso import BaseTestISO
 class TestErcot(BaseTestISO):
     iso = Ercot()
 
+    """get_fuel_mix"""
+
     @pytest.mark.skip
     def test_get_fuel_mix_date_or_start(self):
         pass
@@ -19,9 +21,13 @@ class TestErcot(BaseTestISO):
     def test_get_fuel_mix_historical_with_date_range(self):
         pass
 
+    """get_lmp"""
+
     @pytest.mark.skip
     def test_get_lmp_historical(self, markets=None):
         pass
+
+    """get_load_forecast"""
 
     def test_get_load_forecast_historical(self):
         with pytest.raises(NotSupported):
@@ -30,6 +36,8 @@ class TestErcot(BaseTestISO):
     @pytest.mark.skip
     def test_get_load_forecast_historical_with_date_range(self):
         pass
+
+    """get_load_storage"""
 
     def test_get_storage_historical(self):
         with pytest.raises(NotImplementedError):

--- a/gridstatus/tests/test_gridstatus.py
+++ b/gridstatus/tests/test_gridstatus.py
@@ -7,6 +7,14 @@ from gridstatus.base import GridStatus, ISOBase
 
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
 
+"""
+Legacy gridstatus tests file
+
+General tests should be go to BaseTestISO in base_test_iso.py
+
+ISO-specific tests should go to BaseTestISO subclasses found in test_{iso}.py
+"""
+
 
 def test_make_lmp_availability_df():
     gridstatus.utils.make_lmp_availability_table()

--- a/gridstatus/tests/test_isone2.py
+++ b/gridstatus/tests/test_isone2.py
@@ -2,35 +2,30 @@ import pytest
 
 from gridstatus import ISONE, Markets
 from gridstatus.tests.base_test_iso import BaseTestISO
+from gridstatus.tests.decorators import with_markets
 
 
 class TestISONE(BaseTestISO):
     iso = ISONE()
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.DAY_AHEAD_HOURLY,
-            # Markets.REAL_TIME_5_MIN,
-            Markets.REAL_TIME_HOURLY,
-        ],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
+        # Markets.REAL_TIME_5_MIN,
+        Markets.REAL_TIME_HOURLY,
     )
     def test_get_lmp_historical(self, market):
         super().test_get_lmp_historical(market=market)
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.REAL_TIME_5_MIN,
-            Markets.REAL_TIME_HOURLY,
-        ],
+    @with_markets(
+        Markets.REAL_TIME_5_MIN,
+        Markets.REAL_TIME_HOURLY,
     )
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market=market)
 
-    @pytest.mark.parametrize(
-        "market",
-        [Markets.DAY_AHEAD_HOURLY, Markets.REAL_TIME_5_MIN],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
+        Markets.REAL_TIME_5_MIN,
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)

--- a/gridstatus/tests/test_isone2.py
+++ b/gridstatus/tests/test_isone2.py
@@ -8,6 +8,8 @@ from gridstatus.tests.decorators import with_markets
 class TestISONE(BaseTestISO):
     iso = ISONE()
 
+    """get_lmp"""
+
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
         # Markets.REAL_TIME_5_MIN,
@@ -29,6 +31,8 @@ class TestISONE(BaseTestISO):
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)
+
+    """get_storage"""
 
     def test_get_storage_historical(self):
         with pytest.raises(NotImplementedError):

--- a/gridstatus/tests/test_isone2.py
+++ b/gridstatus/tests/test_isone2.py
@@ -27,3 +27,10 @@ class TestISONE(BaseTestISO):
     )
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market=market)
+
+    @pytest.mark.parametrize(
+        "market",
+        [Markets.DAY_AHEAD_HOURLY, Markets.REAL_TIME_5_MIN],
+    )
+    def test_get_lmp_today(self, market):
+        super().test_get_lmp_today(market=market)

--- a/gridstatus/tests/test_isone2.py
+++ b/gridstatus/tests/test_isone2.py
@@ -35,6 +35,10 @@ class TestISONE(BaseTestISO):
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)
 
+    def test_get_storage_historical(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_historical()
+
     def test_get_storage_today(self):
         with pytest.raises(NotImplementedError):
             super().test_get_storage_today()

--- a/gridstatus/tests/test_isone2.py
+++ b/gridstatus/tests/test_isone2.py
@@ -17,3 +17,13 @@ class TestISONE(BaseTestISO):
     )
     def test_get_lmp_historical(self, market):
         super().test_get_lmp_historical(market=market)
+
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.REAL_TIME_5_MIN,
+            Markets.REAL_TIME_HOURLY,
+        ],
+    )
+    def test_get_lmp_latest(self, market):
+        super().test_get_lmp_latest(market=market)

--- a/gridstatus/tests/test_isone2.py
+++ b/gridstatus/tests/test_isone2.py
@@ -1,0 +1,6 @@
+from gridstatus import ISONE
+from gridstatus.tests.base_test_iso import BaseTestISO
+
+
+class TestISONE(BaseTestISO):
+    iso = ISONE()

--- a/gridstatus/tests/test_isone2.py
+++ b/gridstatus/tests/test_isone2.py
@@ -1,6 +1,19 @@
-from gridstatus import ISONE
+import pytest
+
+from gridstatus import ISONE, Markets
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
 class TestISONE(BaseTestISO):
     iso = ISONE()
+
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.DAY_AHEAD_HOURLY,
+            # Markets.REAL_TIME_5_MIN,
+            Markets.REAL_TIME_HOURLY,
+        ],
+    )
+    def test_get_lmp_historical(self, market):
+        super().test_get_lmp_historical(market=market)

--- a/gridstatus/tests/test_isone2.py
+++ b/gridstatus/tests/test_isone2.py
@@ -34,3 +34,7 @@ class TestISONE(BaseTestISO):
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)
+
+    def test_get_storage_today(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_today()

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -99,16 +99,6 @@ def test_gridstatus_to_dict():
     }
 
 
-@pytest.mark.parametrize(
-    "iso",
-    [CAISO()],
-)
-def test_get_historical_storage(iso):
-    test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
-    storage = iso.get_storage(date=test_date)
-    check_storage(storage)
-
-
 # only testing with caiso, assume works with others
 
 

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -113,52 +113,6 @@ def test_gridstatus_to_dict():
         },
         {
             ISONE(): {
-                # , Markets.REAL_TIME_5_MIN
-                "markets": [Markets.DAY_AHEAD_HOURLY, Markets.REAL_TIME_HOURLY],
-            },
-        },
-        {
-            NYISO(): {
-                "markets": [Markets.DAY_AHEAD_HOURLY, Markets.REAL_TIME_5_MIN],
-            },
-        },
-        {
-            PJM(): {
-                "markets": [
-                    # Markets.REAL_TIME_5_MIN, TODO renable, but too slow
-                    Markets.REAL_TIME_HOURLY,
-                    Markets.DAY_AHEAD_HOURLY,
-                ],
-            },
-        },
-    ],
-)
-def test_get_historical_lmp(test):
-    iso = list(test)[0]
-    markets = test[iso]["markets"]
-
-    date_str = "20220722"
-    for m in markets:
-        print(iso.iso_id, m)
-        hist = iso.get_lmp(date_str, market=m)
-        assert isinstance(hist, pd.DataFrame)
-        check_lmp_columns(hist, m)
-
-
-@pytest.mark.parametrize(
-    "test",
-    [
-        {
-            CAISO(): {
-                "markets": [
-                    Markets.REAL_TIME_15_MIN,
-                    Markets.DAY_AHEAD_HOURLY,
-                    Markets.REAL_TIME_5_MIN,
-                ],
-            },
-        },
-        {
-            ISONE(): {
                 "markets": [Markets.REAL_TIME_5_MIN, Markets.REAL_TIME_HOURLY],
             },
         },

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -8,15 +8,6 @@ from gridstatus.base import GridStatus, ISOBase
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
 
 
-def check_forecast(df):
-    assert set(df.columns) == set(
-        ["Forecast Time", "Time", "Load Forecast"],
-    )
-
-    assert check_is_datetime_type(df["Forecast Time"])
-    assert check_is_datetime_type(df["Time"])
-
-
 def check_status(df):
     assert set(df.columns) == set(
         ["Time", "Status", "Notes"],

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -105,53 +105,6 @@ def test_gridstatus_to_dict():
         {
             CAISO(): {
                 "markets": [
-                    Markets.REAL_TIME_15_MIN,
-                    Markets.DAY_AHEAD_HOURLY,
-                    Markets.REAL_TIME_5_MIN,
-                ],
-            },
-        },
-        {
-            ISONE(): {
-                "markets": [Markets.REAL_TIME_5_MIN, Markets.REAL_TIME_HOURLY],
-            },
-        },
-        {
-            MISO(): {
-                "markets": [Markets.REAL_TIME_5_MIN, Markets.DAY_AHEAD_HOURLY],
-            },
-        },
-        {
-            NYISO(): {
-                "markets": [Markets.DAY_AHEAD_HOURLY, Markets.REAL_TIME_5_MIN],
-            },
-        },
-        {
-            PJM(): {
-                "markets": [
-                    Markets.DAY_AHEAD_HOURLY,
-                ],
-            },
-        },
-    ],
-)
-def test_get_latest_lmp(test):
-    iso = list(test)[0]
-    markets = test[iso]["markets"]
-
-    for m in markets:
-        print(iso.iso_id, m)
-        latest = iso.get_lmp(date="latest", market=m)
-        assert isinstance(latest, pd.DataFrame)
-        check_lmp_columns(latest, m)
-
-
-@pytest.mark.parametrize(
-    "test",
-    [
-        {
-            CAISO(): {
-                "markets": [
                     Markets.REAL_TIME_5_MIN,
                     Markets.REAL_TIME_15_MIN,
                     Markets.DAY_AHEAD_HOURLY,

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import pytest
-from pandas.api.types import is_numeric_dtype
 
 import gridstatus
 from gridstatus import CAISO, ISONE, MISO, NYISO, PJM, SPP, Ercot, Markets
@@ -98,34 +97,6 @@ def test_gridstatus_to_dict():
         "status": "Test",
         "time": time,
     }
-
-
-@pytest.mark.parametrize("iso", [PJM(), NYISO(), ISONE(), CAISO()])
-def test_get_historical_load(iso):
-    # pick a test date 2 weeks back
-    test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
-
-    # date string works
-    date_str = test_date.strftime("%Y%m%d")
-    df = iso.get_load(date_str)
-    assert isinstance(df, pd.DataFrame)
-    assert set(["Time", "Load"]) == set(df.columns)
-    assert df.loc[0]["Time"].strftime("%Y%m%d") == date_str
-    assert is_numeric_dtype(df["Load"])
-
-    # timestamp object works
-    df = iso.get_load(test_date)
-    assert isinstance(df, pd.DataFrame)
-    assert set(["Time", "Load"]) == set(df.columns)
-    assert df.loc[0]["Time"].strftime("%Y%m%d") == test_date.strftime("%Y%m%d")
-    assert is_numeric_dtype(df["Load"])
-
-    # datetime object works
-    df = iso.get_load(test_date)
-    assert isinstance(df, pd.DataFrame)
-    assert set(["Time", "Load"]) == set(df.columns)
-    assert df.loc[0]["Time"].strftime("%Y%m%d") == test_date.strftime("%Y%m%d")
-    assert is_numeric_dtype(df["Load"])
 
 
 @pytest.mark.parametrize(

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -4,7 +4,7 @@ from pandas.api.types import is_numeric_dtype
 
 import gridstatus
 from gridstatus import CAISO, ISONE, MISO, NYISO, PJM, SPP, Ercot, Markets
-from gridstatus.base import FuelMix, GridStatus, ISOBase
+from gridstatus.base import GridStatus, ISOBase
 
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
 
@@ -55,18 +55,6 @@ def check_is_datetime_type(series):
 
 def test_make_lmp_availability_df():
     gridstatus.utils.make_lmp_availability_table()
-
-
-@pytest.mark.parametrize("iso", all_isos)
-def test_get_latest_fuel_mix(iso):
-    mix = iso.get_fuel_mix("latest")
-    assert isinstance(mix, FuelMix)
-    assert isinstance(mix.time, pd.Timestamp)
-    assert isinstance(mix.mix, pd.DataFrame)
-    assert repr(mix)
-    assert len(mix.mix) > 0
-    assert mix.iso == iso.name
-    assert isinstance(repr(mix), str)
 
 
 @pytest.mark.parametrize("iso", [Ercot(), ISONE(), NYISO(), CAISO(), PJM()])

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -101,16 +101,6 @@ def test_gridstatus_to_dict():
 
 
 @pytest.mark.parametrize("iso", all_isos)
-def test_get_load_today(iso):
-    df = iso.get_load("today")
-    assert isinstance(df, pd.DataFrame)
-    assert ["Time", "Load"] == df.columns.tolist()
-    assert is_numeric_dtype(df["Load"])
-    assert isinstance(df.loc[0]["Time"], pd.Timestamp)
-    assert df.loc[0]["Time"].tz is not None
-
-
-@pytest.mark.parametrize("iso", all_isos)
 def test_get_latest_load(iso):
     load = iso.get_load("latest")
     set(["time", "load"]) == load.keys()

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -82,15 +82,6 @@ def test_handle_date_today_tz():
     assert date.tzinfo.zone == tz
 
 
-@pytest.mark.parametrize("iso", [SPP(), NYISO(), ISONE(), CAISO(), Ercot()])
-def test_get_latest_status(iso):
-    status = iso.get_status("latest")
-    assert isinstance(status, GridStatus)
-
-    # ensure there is a homepage if gridstatus can retrieve a status
-    assert isinstance(iso.status_homepage, str)
-
-
 def test_gridstatus_to_dict():
     time = pd.Timestamp.now()
     notes = ["note1", "note2"]

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 import gridstatus
-from gridstatus import CAISO, ISONE, MISO, NYISO, PJM, SPP, Ercot, Markets
+from gridstatus import CAISO, ISONE, MISO, NYISO, PJM, SPP, Ercot
 from gridstatus.base import GridStatus, ISOBase
 
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
@@ -97,47 +97,6 @@ def test_gridstatus_to_dict():
         "status": "Test",
         "time": time,
     }
-
-
-@pytest.mark.parametrize(
-    "test",
-    [
-        {
-            CAISO(): {
-                "markets": [
-                    Markets.REAL_TIME_5_MIN,
-                    Markets.REAL_TIME_15_MIN,
-                    Markets.DAY_AHEAD_HOURLY,
-                ],
-            },
-        },
-        {
-            ISONE(): {
-                "markets": [Markets.DAY_AHEAD_HOURLY, Markets.REAL_TIME_5_MIN],
-            },
-        },
-        {
-            NYISO(): {
-                "markets": [Markets.DAY_AHEAD_HOURLY, Markets.REAL_TIME_5_MIN],
-            },
-        },
-        {
-            PJM(): {
-                "markets": [
-                    Markets.DAY_AHEAD_HOURLY,
-                ],
-            },
-        },
-    ],
-)
-def test_get_lmp_today(test):
-    iso = list(test)[0]
-    markets = test[iso]["markets"]
-
-    for m in markets:
-        today = iso.get_lmp(date="today", market=m)
-        assert isinstance(today, pd.DataFrame)
-        check_lmp_columns(today, m)
 
 
 @pytest.mark.parametrize("iso", [ISONE(), CAISO(), NYISO()])

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -100,13 +100,6 @@ def test_gridstatus_to_dict():
     }
 
 
-@pytest.mark.parametrize("iso", all_isos)
-def test_get_latest_load(iso):
-    load = iso.get_load("latest")
-    set(["time", "load"]) == load.keys()
-    assert is_numeric_dtype(type(load["load"]))
-
-
 @pytest.mark.parametrize("iso", [PJM(), NYISO(), ISONE(), CAISO()])
 def test_get_historical_load(iso):
     # pick a test date 2 weeks back

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -114,16 +114,6 @@ def test_end_is_today():
 
 
 @pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
-def test_get_historical_load_with_date_range(iso):
-    num_days = 7
-    end = pd.Timestamp.now(tz=iso.default_timezone) + pd.Timedelta(days=1)
-    start = end - pd.Timedelta(days=num_days)
-    data = iso.get_load(date=start.date(), end=end.date())
-    # make sure right number of days are returned
-    assert data["Time"].dt.day.nunique() == num_days
-
-
-@pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
 def test_date_or_start(iso):
     num_days = 2
     end = pd.Timestamp.now(tz=iso.default_timezone)

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -133,18 +133,6 @@ def test_end_is_today():
 
 
 @pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
-def test_get_fuel_mix_with_date_range(iso):
-    # range not inclusive, add one to include today
-    num_days = 7
-    end = pd.Timestamp.now(tz=iso.default_timezone) + pd.Timedelta(days=1)
-    start = end - pd.Timedelta(days=num_days)
-
-    data = iso.get_fuel_mix(date=start.date(), end=end.date())
-    # make sure right number of days are returned
-    assert data["Time"].dt.day.nunique() == num_days
-
-
-@pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
 def test_get_historical_load_with_date_range(iso):
     num_days = 7
     end = pd.Timestamp.now(tz=iso.default_timezone) + pd.Timedelta(days=1)

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -101,15 +101,6 @@ def test_gridstatus_to_dict():
 
 @pytest.mark.parametrize(
     "iso",
-    [PJM(), MISO(), SPP(), Ercot(), ISONE(), CAISO(), NYISO()],
-)
-def test_get_load_forecast_today(iso):
-    forecast = iso.get_load_forecast("today")
-    check_forecast(forecast)
-
-
-@pytest.mark.parametrize(
-    "iso",
     [CAISO()],
 )
 def test_get_storage_today(iso):

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -8,23 +8,6 @@ from gridstatus.base import GridStatus, ISOBase
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
 
 
-def check_lmp_columns(df, market):
-    assert set(
-        [
-            "Time",
-            "Market",
-            "Location",
-            "Location Type",
-            "LMP",
-            "Energy",
-            "Congestion",
-            "Loss",
-        ],
-    ).issubset(df.columns)
-
-    assert df["Market"].unique()[0] == market.value
-
-
 def check_forecast(df):
     assert set(df.columns) == set(
         ["Forecast Time", "Time", "Load Forecast"],

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -34,12 +34,6 @@ def check_forecast(df):
     assert check_is_datetime_type(df["Time"])
 
 
-def check_storage(df):
-    assert set(df.columns) == set(
-        ["Time", "Supply", "Type"],
-    )
-
-
 def check_status(df):
     assert set(df.columns) == set(
         ["Time", "Status", "Notes"],

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -57,12 +57,6 @@ def test_make_lmp_availability_df():
     gridstatus.utils.make_lmp_availability_table()
 
 
-@pytest.mark.parametrize("iso", [Ercot(), ISONE(), NYISO(), CAISO(), PJM()])
-def test_get_fuel_mix_today(iso):
-    df = iso.get_fuel_mix("today")
-    assert isinstance(df, pd.DataFrame)
-
-
 def test_list_isos():
     assert len(gridstatus.list_isos()) == 7
 

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -8,12 +8,6 @@ from gridstatus.base import GridStatus, ISOBase
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
 
 
-def check_status(df):
-    assert set(df.columns) == set(
-        ["Time", "Status", "Notes"],
-    )
-
-
 def check_is_datetime_type(series):
     return pd.core.dtypes.common.is_datetime64_ns_dtype(
         series,

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -103,15 +103,6 @@ def test_gridstatus_to_dict():
     "iso",
     [CAISO()],
 )
-def test_get_storage_today(iso):
-    storage = iso.get_storage("today")
-    check_storage(storage)
-
-
-@pytest.mark.parametrize(
-    "iso",
-    [CAISO()],
-)
 def test_get_historical_storage(iso):
     test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
     storage = iso.get_storage(date=test_date)

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -99,25 +99,6 @@ def test_gridstatus_to_dict():
     }
 
 
-@pytest.mark.parametrize("iso", [ISONE(), CAISO(), NYISO()])
-def test_get_historical_load_forecast(iso):
-    test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
-    forecast = iso.get_load_forecast(date=test_date)
-    check_forecast(forecast)
-
-
-@pytest.mark.parametrize("iso", [NYISO(), ISONE(), CAISO()])
-def test_get_historical_forecast_with_date_range(iso):
-    end = pd.Timestamp.now().normalize() - pd.Timedelta(days=14)
-    start = (end - pd.Timedelta(days=7)).date()
-
-    forecast = forecast = iso.get_load_forecast(
-        start=start,
-        end=end,
-    )
-    check_forecast(forecast)
-
-
 @pytest.mark.parametrize(
     "iso",
     [PJM(), MISO(), SPP(), Ercot(), ISONE(), CAISO(), NYISO()],

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -100,30 +100,6 @@ def test_gridstatus_to_dict():
     }
 
 
-@pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
-def test_get_historical_fuel_mix(iso):
-    # date string works
-    date_str = "04/03/2022"
-    df = iso.get_fuel_mix(date_str)
-    assert isinstance(df, pd.DataFrame)
-    assert df.loc[0]["Time"].strftime("%m/%d/%Y") == date_str
-    assert df.loc[0]["Time"].tz is not None
-
-    # timestamp object works
-    date_obj = pd.to_datetime("2019/11/19")
-    df = iso.get_fuel_mix(date_obj)
-    assert isinstance(df, pd.DataFrame)
-    assert df.loc[0]["Time"].strftime("%Y%m%d") == date_obj.strftime("%Y%m%d")
-    assert df.loc[0]["Time"].tz is not None
-
-    # datetime object works
-    date_obj = pd.to_datetime("2021/05/09").date()
-    df = iso.get_fuel_mix(date_obj)
-    assert isinstance(df, pd.DataFrame)
-    assert df.loc[0]["Time"].strftime("%Y%m%d") == date_obj.strftime("%Y%m%d")
-    assert df.loc[0]["Time"].tz is not None
-
-
 @pytest.mark.parametrize("iso", all_isos)
 def test_get_load_today(iso):
     df = iso.get_load("today")

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -8,12 +8,6 @@ from gridstatus.base import GridStatus, ISOBase
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
 
 
-def check_is_datetime_type(series):
-    return pd.core.dtypes.common.is_datetime64_ns_dtype(
-        series,
-    ) | pd.core.dtypes.common.is_timedelta64_ns_dtype(series)
-
-
 def test_make_lmp_availability_df():
     gridstatus.utils.make_lmp_availability_table()
 

--- a/gridstatus/tests/test_isos.py
+++ b/gridstatus/tests/test_isos.py
@@ -113,24 +113,6 @@ def test_end_is_today():
     assert data["Time"].dt.day.nunique() == num_days
 
 
-@pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
-def test_date_or_start(iso):
-    num_days = 2
-    end = pd.Timestamp.now(tz=iso.default_timezone)
-    start = end - pd.Timedelta(days=num_days)
-
-    iso.get_fuel_mix(date=start.date(), end=end.date())
-    iso.get_fuel_mix(
-        start=start.date(),
-        end=end.date(),
-    )
-    iso.get_fuel_mix(date=start.date())
-    iso.get_fuel_mix(start=start.date())
-
-    with pytest.raises(ValueError):
-        iso.get_fuel_mix(start=start.date(), date=start.date())
-
-
 def test_end_before_start_raises_error():
     iso = CAISO()
     with pytest.raises(AssertionError):

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -8,6 +8,8 @@ from gridstatus.tests.decorators import with_markets
 class TestMISO(BaseTestISO):
     iso = MISO()
 
+    """get_fuel_mix"""
+
     @pytest.mark.skip
     def test_get_fuel_mix_date_or_start(self):
         pass
@@ -24,6 +26,8 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
 
+    """get_lmp"""
+
     @with_markets(
         Markets.REAL_TIME_5_MIN,
         Markets.DAY_AHEAD_HOURLY,
@@ -39,6 +43,8 @@ class TestMISO(BaseTestISO):
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market)
 
+    """get_load_forecast"""
+
     def test_get_load_forecast_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
@@ -46,6 +52,8 @@ class TestMISO(BaseTestISO):
     @pytest.mark.skip
     def test_get_load_forecast_historical_with_date_range(self):
         pass
+
+    """get_load"""
 
     def test_get_load_historical(self):
         with pytest.raises(NotSupported):
@@ -55,9 +63,13 @@ class TestMISO(BaseTestISO):
     def test_get_load_historical_with_date_range(self):
         pass
 
+    """get_status"""
+
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()
+
+    """get_storage"""
 
     def test_get_storage_historical(self):
         with pytest.raises(NotImplementedError):

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -15,6 +15,10 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
 
+    def test_get_load_historical(self):
+        with pytest.raises(NotSupported):
+            super().test_get_load_historical()
+
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -1,0 +1,6 @@
+from gridstatus import MISO
+from gridstatus.tests.base_test_iso import BaseTestISO
+
+
+class TestMISO(BaseTestISO):
+    iso = MISO()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gridstatus import MISO, NotSupported
+from gridstatus import MISO, Markets, NotSupported
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
@@ -14,6 +14,17 @@ class TestMISO(BaseTestISO):
     def test_get_fuel_mix_today(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
+
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.REAL_TIME_5_MIN,
+            Markets.DAY_AHEAD_HOURLY,
+        ],
+    )
+    def test_get_lmp_historical(self, market):
+        with pytest.raises(NotSupported):
+            super().test_get_lmp_historical(market)
 
     def test_get_load_historical(self):
         with pytest.raises(NotSupported):

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -2,6 +2,7 @@ import pytest
 
 from gridstatus import MISO, Markets, NotSupported
 from gridstatus.tests.base_test_iso import BaseTestISO
+from gridstatus.tests.decorators import with_markets
 
 
 class TestMISO(BaseTestISO):
@@ -21,23 +22,17 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.REAL_TIME_5_MIN,
-            Markets.DAY_AHEAD_HOURLY,
-        ],
+    @with_markets(
+        Markets.REAL_TIME_5_MIN,
+        Markets.DAY_AHEAD_HOURLY,
     )
     def test_get_lmp_historical(self, market):
         with pytest.raises(NotSupported):
             super().test_get_lmp_historical(market)
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.REAL_TIME_5_MIN,
-            Markets.DAY_AHEAD_HOURLY,
-        ],
+    @with_markets(
+        Markets.REAL_TIME_5_MIN,
+        Markets.DAY_AHEAD_HOURLY,
     )
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market)

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -10,7 +10,7 @@ class TestMISO(BaseTestISO):
 
     """get_fuel_mix"""
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_fuel_mix_date_or_start(self):
         pass
 
@@ -18,7 +18,7 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_fuel_mix_historical_with_date_range(self):
         pass
 
@@ -49,7 +49,7 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 
@@ -59,7 +59,7 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_load_historical_with_date_range(self):
         pass
 

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -10,3 +10,7 @@ class TestMISO(BaseTestISO):
     def test_get_fuel_mix_today(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
+
+    def test_get_status_latest(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_status_latest()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -36,6 +36,10 @@ class TestMISO(BaseTestISO):
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market)
 
+    def test_get_load_forecast_historical(self):
+        with pytest.raises(NotSupported):
+            super().test_get_load_forecast_historical()
+
     def test_get_load_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -7,6 +7,9 @@ from gridstatus.tests.base_test_iso import BaseTestISO
 class TestMISO(BaseTestISO):
     iso = MISO()
 
+    def test_get_fuel_mix_date_or_start(self):
+        pass
+
     def test_get_fuel_mix_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -7,6 +7,10 @@ from gridstatus.tests.base_test_iso import BaseTestISO
 class TestMISO(BaseTestISO):
     iso = MISO()
 
+    def test_get_fuel_mix_historical(self):
+        with pytest.raises(NotSupported):
+            super().test_get_fuel_mix_historical()
+
     def test_get_fuel_mix_today(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -40,6 +40,9 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
 
+    def test_get_load_forecast_historical_with_date_range(self):
+        pass
+
     def test_get_load_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -54,6 +54,10 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()
 
+    def test_get_storage_historical(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_historical()
+
     def test_get_storage_today(self):
         with pytest.raises(NotImplementedError):
             super().test_get_storage_today()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -8,6 +8,7 @@ from gridstatus.tests.decorators import with_markets
 class TestMISO(BaseTestISO):
     iso = MISO()
 
+    @pytest.mark.skip
     def test_get_fuel_mix_date_or_start(self):
         pass
 
@@ -15,6 +16,7 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
 
+    @pytest.mark.skip
     def test_get_fuel_mix_historical_with_date_range(self):
         pass
 
@@ -41,6 +43,7 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
 
+    @pytest.mark.skip
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 
@@ -48,6 +51,7 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()
 
+    @pytest.mark.skip
     def test_get_load_historical_with_date_range(self):
         pass
 

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -53,3 +53,7 @@ class TestMISO(BaseTestISO):
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()
+
+    def test_get_storage_today(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_today()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -1,6 +1,12 @@
-from gridstatus import MISO
+import pytest
+
+from gridstatus import MISO, NotSupported
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
 class TestMISO(BaseTestISO):
     iso = MISO()
+
+    def test_get_fuel_mix_today(self):
+        with pytest.raises(NotSupported):
+            super().test_get_fuel_mix_today()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -26,6 +26,16 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_lmp_historical(market)
 
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.REAL_TIME_5_MIN,
+            Markets.DAY_AHEAD_HOURLY,
+        ],
+    )
+    def test_get_lmp_latest(self, market):
+        super().test_get_lmp_latest(market)
+
     def test_get_load_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -11,6 +11,9 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
 
+    def test_get_fuel_mix_historical_with_date_range(self):
+        pass
+
     def test_get_fuel_mix_today(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()

--- a/gridstatus/tests/test_miso2.py
+++ b/gridstatus/tests/test_miso2.py
@@ -50,6 +50,9 @@ class TestMISO(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()
 
+    def test_get_load_historical_with_date_range(self):
+        pass
+
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()

--- a/gridstatus/tests/test_nyiso.py
+++ b/gridstatus/tests/test_nyiso.py
@@ -2,7 +2,12 @@ import pytest
 
 import gridstatus
 from gridstatus.base import Markets
-from gridstatus.tests.test_isos import check_status
+
+
+def check_status(df):
+    assert set(df.columns) == set(
+        ["Time", "Status", "Notes"],
+    )
 
 
 def test_nyiso_date_range():

--- a/gridstatus/tests/test_nyiso2.py
+++ b/gridstatus/tests/test_nyiso2.py
@@ -26,3 +26,10 @@ class TestNYISO(BaseTestISO):
     )
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market=market)
+
+    @pytest.mark.parametrize(
+        "market",
+        [Markets.DAY_AHEAD_HOURLY, Markets.REAL_TIME_5_MIN],
+    )
+    def test_get_lmp_today(self, market):
+        super().test_get_lmp_today(market=market)

--- a/gridstatus/tests/test_nyiso2.py
+++ b/gridstatus/tests/test_nyiso2.py
@@ -16,3 +16,13 @@ class TestNYISO(BaseTestISO):
     )
     def test_get_lmp_historical(self, market):
         super().test_get_lmp_historical(market=market)
+
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.DAY_AHEAD_HOURLY,
+            Markets.REAL_TIME_5_MIN,
+        ],
+    )
+    def test_get_lmp_latest(self, market):
+        super().test_get_lmp_latest(market=market)

--- a/gridstatus/tests/test_nyiso2.py
+++ b/gridstatus/tests/test_nyiso2.py
@@ -34,6 +34,10 @@ class TestNYISO(BaseTestISO):
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)
 
+    def test_get_storage_historical(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_historical()
+
     def test_get_storage_today(self):
         with pytest.raises(NotImplementedError):
             super().test_get_storage_today()

--- a/gridstatus/tests/test_nyiso2.py
+++ b/gridstatus/tests/test_nyiso2.py
@@ -1,6 +1,18 @@
-from gridstatus import NYISO
+import pytest
+
+from gridstatus import NYISO, Markets
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
 class TestNYISO(BaseTestISO):
     iso = NYISO()
+
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.DAY_AHEAD_HOURLY,
+            Markets.REAL_TIME_5_MIN,
+        ],
+    )
+    def test_get_lmp_historical(self, market):
+        super().test_get_lmp_historical(market=market)

--- a/gridstatus/tests/test_nyiso2.py
+++ b/gridstatus/tests/test_nyiso2.py
@@ -33,3 +33,7 @@ class TestNYISO(BaseTestISO):
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)
+
+    def test_get_storage_today(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_today()

--- a/gridstatus/tests/test_nyiso2.py
+++ b/gridstatus/tests/test_nyiso2.py
@@ -1,0 +1,6 @@
+from gridstatus import NYISO
+from gridstatus.tests.base_test_iso import BaseTestISO
+
+
+class TestNYISO(BaseTestISO):
+    iso = NYISO()

--- a/gridstatus/tests/test_nyiso2.py
+++ b/gridstatus/tests/test_nyiso2.py
@@ -8,6 +8,8 @@ from gridstatus.tests.decorators import with_markets
 class TestNYISO(BaseTestISO):
     iso = NYISO()
 
+    """get_lmp"""
+
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
         Markets.REAL_TIME_5_MIN,
@@ -28,6 +30,8 @@ class TestNYISO(BaseTestISO):
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)
+
+    """get_storage"""
 
     def test_get_storage_historical(self):
         with pytest.raises(NotImplementedError):

--- a/gridstatus/tests/test_nyiso2.py
+++ b/gridstatus/tests/test_nyiso2.py
@@ -2,34 +2,29 @@ import pytest
 
 from gridstatus import NYISO, Markets
 from gridstatus.tests.base_test_iso import BaseTestISO
+from gridstatus.tests.decorators import with_markets
 
 
 class TestNYISO(BaseTestISO):
     iso = NYISO()
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.DAY_AHEAD_HOURLY,
-            Markets.REAL_TIME_5_MIN,
-        ],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
+        Markets.REAL_TIME_5_MIN,
     )
     def test_get_lmp_historical(self, market):
         super().test_get_lmp_historical(market=market)
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.DAY_AHEAD_HOURLY,
-            Markets.REAL_TIME_5_MIN,
-        ],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
+        Markets.REAL_TIME_5_MIN,
     )
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market=market)
 
-    @pytest.mark.parametrize(
-        "market",
-        [Markets.DAY_AHEAD_HOURLY, Markets.REAL_TIME_5_MIN],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
+        Markets.REAL_TIME_5_MIN,
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -4,7 +4,23 @@ import pytest
 import gridstatus
 from gridstatus.base import Markets
 from gridstatus.decorators import _get_pjm_archive_date
-from gridstatus.tests.test_isos import check_lmp_columns
+
+
+def check_lmp_columns(df, market):
+    assert set(
+        [
+            "Time",
+            "Market",
+            "Location",
+            "Location Type",
+            "LMP",
+            "Energy",
+            "Congestion",
+            "Loss",
+        ],
+    ).issubset(df.columns)
+
+    assert df["Market"].unique()[0] == market.value
 
 
 def test_pjm_no_data():

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -1,11 +1,22 @@
 import pytest
 
-from gridstatus import PJM
+from gridstatus import PJM, Markets
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
 class TestPJM(BaseTestISO):
     iso = PJM()
+
+    @pytest.mark.parametrize(
+        "market",
+        [
+            # Markets.REAL_TIME_5_MIN, # TODO reenable, but too slow
+            Markets.REAL_TIME_HOURLY,
+            Markets.DAY_AHEAD_HOURLY,
+        ],
+    )
+    def test_get_lmp_historical(self, market):
+        super().test_get_lmp_historical(market=market)
 
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -27,6 +27,15 @@ class TestPJM(BaseTestISO):
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market=market)
 
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.DAY_AHEAD_HOURLY,
+        ],
+    )
+    def test_get_lmp_today(self, market):
+        super().test_get_lmp_today(market=market)
+
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -1,0 +1,6 @@
+from gridstatus import PJM
+from gridstatus.tests.base_test_iso import BaseTestISO
+
+
+class TestPJM(BaseTestISO):
+    iso = PJM()

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -36,7 +36,7 @@ class TestPJM(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -46,3 +46,7 @@ class TestPJM(BaseTestISO):
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()
+
+    def test_get_storage_today(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_today()

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -1,6 +1,12 @@
+import pytest
+
 from gridstatus import PJM
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
 class TestPJM(BaseTestISO):
     iso = PJM()
+
+    def test_get_status_latest(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_status_latest()

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -18,6 +18,15 @@ class TestPJM(BaseTestISO):
     def test_get_lmp_historical(self, market):
         super().test_get_lmp_historical(market=market)
 
+    @pytest.mark.parametrize(
+        "market",
+        [
+            Markets.DAY_AHEAD_HOURLY,
+        ],
+    )
+    def test_get_lmp_latest(self, market):
+        super().test_get_lmp_latest(market=market)
+
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -47,6 +47,10 @@ class TestPJM(BaseTestISO):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()
 
+    def test_get_storage_historical(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_historical()
+
     def test_get_storage_today(self):
         with pytest.raises(NotImplementedError):
             super().test_get_storage_today()

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -40,6 +40,9 @@ class TestPJM(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
 
+    def test_get_load_forecast_historical_with_date_range(self):
+        pass
+
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gridstatus import PJM, Markets
+from gridstatus import PJM, Markets, NotSupported
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
@@ -35,6 +35,10 @@ class TestPJM(BaseTestISO):
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)
+
+    def test_get_load_forecast_historical(self):
+        with pytest.raises(NotSupported):
+            super().test_get_load_forecast_historical()
 
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -8,6 +8,8 @@ from gridstatus.tests.decorators import with_markets
 class TestPJM(BaseTestISO):
     iso = PJM()
 
+    """get_lmp"""
+
     @with_markets(
         # Markets.REAL_TIME_5_MIN, # TODO reenable, but too slow
         Markets.REAL_TIME_HOURLY,
@@ -28,6 +30,8 @@ class TestPJM(BaseTestISO):
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)
 
+    """get_load_forecast"""
+
     def test_get_load_forecast_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
@@ -39,6 +43,8 @@ class TestPJM(BaseTestISO):
     def test_get_status_latest(self):
         with pytest.raises(NotImplementedError):
             super().test_get_status_latest()
+
+    """get_load_storage"""
 
     def test_get_storage_historical(self):
         with pytest.raises(NotImplementedError):

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -32,6 +32,7 @@ class TestPJM(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_forecast_historical()
 
+    @pytest.mark.skip
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 

--- a/gridstatus/tests/test_pjm2.py
+++ b/gridstatus/tests/test_pjm2.py
@@ -2,36 +2,28 @@ import pytest
 
 from gridstatus import PJM, Markets, NotSupported
 from gridstatus.tests.base_test_iso import BaseTestISO
+from gridstatus.tests.decorators import with_markets
 
 
 class TestPJM(BaseTestISO):
     iso = PJM()
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            # Markets.REAL_TIME_5_MIN, # TODO reenable, but too slow
-            Markets.REAL_TIME_HOURLY,
-            Markets.DAY_AHEAD_HOURLY,
-        ],
+    @with_markets(
+        # Markets.REAL_TIME_5_MIN, # TODO reenable, but too slow
+        Markets.REAL_TIME_HOURLY,
+        Markets.DAY_AHEAD_HOURLY,
     )
     def test_get_lmp_historical(self, market):
         super().test_get_lmp_historical(market=market)
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.DAY_AHEAD_HOURLY,
-        ],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
     )
     def test_get_lmp_latest(self, market):
         super().test_get_lmp_latest(market=market)
 
-    @pytest.mark.parametrize(
-        "market",
-        [
-            Markets.DAY_AHEAD_HOURLY,
-        ],
+    @with_markets(
+        Markets.DAY_AHEAD_HOURLY,
     )
     def test_get_lmp_today(self, market):
         super().test_get_lmp_today(market=market)

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -7,6 +7,8 @@ from gridstatus.tests.base_test_iso import BaseTestISO
 class TestSPP(BaseTestISO):
     iso = SPP()
 
+    """get_fuel_mix"""
+
     @pytest.mark.skip
     def test_get_fuel_mix_date_or_start(self):
         pass
@@ -23,9 +25,13 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
 
+    """get_load_forecast"""
+
     @pytest.mark.skip
     def test_get_load_forecast_historical_with_date_range(self):
         pass
+
+    """get_load"""
 
     def test_get_load_historical(self):
         with pytest.raises(NotSupported):
@@ -35,10 +41,14 @@ class TestSPP(BaseTestISO):
     def test_get_load_historical_with_date_range(self):
         pass
 
+    """get_status"""
+
     # TODO: https://github.com/kmax12/gridstatus/issues/109
     def test_get_status_latest(self):
         with pytest.raises(ValueError):
             super().test_get_status_latest()
+
+    """get_storage"""
 
     def test_get_storage_historical(self):
         with pytest.raises(NotImplementedError):

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -7,6 +7,9 @@ from gridstatus.tests.base_test_iso import BaseTestISO
 class TestSPP(BaseTestISO):
     iso = SPP()
 
+    def test_get_fuel_mix_date_or_start(self):
+        pass
+
     def test_get_fuel_mix_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -9,7 +9,7 @@ class TestSPP(BaseTestISO):
 
     """get_fuel_mix"""
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_fuel_mix_date_or_start(self):
         pass
 
@@ -17,7 +17,7 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_fuel_mix_historical_with_date_range(self):
         pass
 
@@ -27,7 +27,7 @@ class TestSPP(BaseTestISO):
 
     """get_load_forecast"""
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 
@@ -37,7 +37,7 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="Not Applicable")
     def test_get_load_historical_with_date_range(self):
         pass
 

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -25,6 +25,9 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()
 
+    def test_get_load_historical_with_date_range(self):
+        pass
+
     # TODO: https://github.com/kmax12/gridstatus/issues/109
     def test_get_status_latest(self):
         with pytest.raises(ValueError):

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -15,6 +15,9 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
 
+    def test_get_load_forecast_historical_with_date_range(self):
+        pass
+
     def test_get_load_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -10,3 +10,8 @@ class TestSPP(BaseTestISO):
     def test_get_fuel_mix_today(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
+
+    # TODO: https://github.com/kmax12/gridstatus/issues/109
+    def test_get_status_latest(self):
+        with pytest.raises(ValueError):
+            super().test_get_status_latest()

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -1,0 +1,6 @@
+from gridstatus import SPP
+from gridstatus.tests.base_test_iso import BaseTestISO
+
+
+class TestSPP(BaseTestISO):
+    iso = SPP()

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -7,6 +7,7 @@ from gridstatus.tests.base_test_iso import BaseTestISO
 class TestSPP(BaseTestISO):
     iso = SPP()
 
+    @pytest.mark.skip
     def test_get_fuel_mix_date_or_start(self):
         pass
 
@@ -14,6 +15,7 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
 
+    @pytest.mark.skip
     def test_get_fuel_mix_historical_with_date_range(self):
         pass
 
@@ -21,6 +23,7 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
 
+    @pytest.mark.skip
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 
@@ -28,6 +31,7 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()
 
+    @pytest.mark.skip
     def test_get_load_historical_with_date_range(self):
         pass
 

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -1,6 +1,12 @@
-from gridstatus import SPP
+import pytest
+
+from gridstatus import SPP, NotSupported
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
 class TestSPP(BaseTestISO):
     iso = SPP()
+
+    def test_get_fuel_mix_today(self):
+        with pytest.raises(NotSupported):
+            super().test_get_fuel_mix_today()

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -11,6 +11,9 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_historical()
 
+    def test_get_fuel_mix_historical_with_date_range(self):
+        pass
+
     def test_get_fuel_mix_today(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -30,6 +30,10 @@ class TestSPP(BaseTestISO):
         with pytest.raises(ValueError):
             super().test_get_status_latest()
 
+    def test_get_storage_historical(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_historical()
+
     def test_get_storage_today(self):
         with pytest.raises(NotImplementedError):
             super().test_get_storage_today()

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -29,3 +29,7 @@ class TestSPP(BaseTestISO):
     def test_get_status_latest(self):
         with pytest.raises(ValueError):
             super().test_get_status_latest()
+
+    def test_get_storage_today(self):
+        with pytest.raises(NotImplementedError):
+            super().test_get_storage_today()

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -15,6 +15,10 @@ class TestSPP(BaseTestISO):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()
 
+    def test_get_load_historical(self):
+        with pytest.raises(NotSupported):
+            super().test_get_load_historical()
+
     # TODO: https://github.com/kmax12/gridstatus/issues/109
     def test_get_status_latest(self):
         with pytest.raises(ValueError):

--- a/gridstatus/tests/test_spp2.py
+++ b/gridstatus/tests/test_spp2.py
@@ -7,6 +7,10 @@ from gridstatus.tests.base_test_iso import BaseTestISO
 class TestSPP(BaseTestISO):
     iso = SPP()
 
+    def test_get_fuel_mix_historical(self):
+        with pytest.raises(NotSupported):
+            super().test_get_fuel_mix_historical()
+
     def test_get_fuel_mix_today(self):
         with pytest.raises(NotSupported):
             super().test_get_fuel_mix_today()


### PR DESCRIPTION
Addresses the beginning of #118:

* moves parametrized tests from `test_isos.py` into `class BaseTestISO`
* standardizes on `def test_{method}_*` for ease of use, e.g. `test_get_historical_lmp` becomes `test_get_lmp_historical`
* creates subclasses, e.g. `class TestErcot(BaseTestISO)` in parallel files, e.g. `gridstatus/tests/test_ercot2.py`
* adds a `@with_markets` decorator which wraps `pytest.mark.parametrize("market")`

Once we finalize the approach, we can either:

* merge this PR, possibly creating double testing,
* OR continue porting tests into the subclasses, and then collapsing the parallel files into the final files, e.g. `gridstatus/tests/test_ercot2.py -> gridstatus/tests/test_ercot.py`