### PR TITLE
Update GitHub action used to publish PyPI package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,14 +14,7 @@ jobs:
           python-version: "3.8"
       - name: Build distribution 📦
         run: make package
-      - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: false
       - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,30 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-      - name: Build distribution 📦
-        run: make package
-      - name: Publish distribution 📦 to PyPI
+      - name: Install packaging
+        run: |
+          python -m pip install pep517
+          python -m pip install packaging
+      - name: Check package version (compare package version with tag)
+        id: check_package_version
+        shell: python
+        run: |
+          from pep517.meta import load
+          from packaging.version import parse
+          metadata = load('.')
+          package_version = metadata.version
+          if parse(package_version) != parse('${{ github.event.release.tag_name }}'):
+            print(f'version mismatch: {package_version} (in package) vs ${{ github.event.release.tag_name }} (GitHub tag)')
+            exit(1)
+          else:
+            print('version match')
+            exit(0)
+      - name: Build distribution
+        run: |
+          rm -rf docs/ gridstatus/tests/ utils/ dist/ build/ unpacked/
+          make package
+      - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          user: 'kmax12'
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,18 +1,27 @@
+name: Release
 on:
   release:
     types: [published]
-
-name: Release
 jobs:
   pypi:
     name: PyPI Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: PyPI Upload
-        uses: FeatureLabs/gh-action-pypi-upload@v2
-        env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          TEST_PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
-          TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Build distribution 📦
+        run: make package
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: false
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
- Use the official GitHub action to release packages on PyPi
- @kmax12 You will need to create an PyPI API Token and add it as an GitHub env secret (`PYPI_API_TOKEN`)