### PR TITLE
Remove Redundant Tests

### DIFF
--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -219,6 +219,8 @@ class BaseTestISO:
 
     @staticmethod
     def _check_lmp_columns(df, market):
+        # todo in future all ISO should return same columns
+        # maybe with the exception of "LMP" breakdown
         assert set(
             [
                 "Time",
@@ -231,7 +233,9 @@ class BaseTestISO:
                 "Loss",
             ],
         ).issubset(df.columns)
+        assert len(df["Market"].unique()) == 1
         assert df["Market"].unique()[0] == market.value
+        assert df.shape[0] >= 0
 
     def _check_storage(self, df):
         assert set(df.columns) == set(

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -149,7 +149,8 @@ class BaseTestISO:
         load = self.iso.get_load("latest")
         set(["time", "load"]) == load.keys()
         assert is_numeric_dtype(type(load["load"]))
-        return load
+        today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
+        assert load["time"].date() == today
 
     def test_get_load_today(self):
         df = self.iso.get_load("today")
@@ -158,7 +159,8 @@ class BaseTestISO:
         assert is_numeric_dtype(df["Load"])
         assert isinstance(df.loc[0]["Time"], pd.Timestamp)
         assert df.loc[0]["Time"].tz is not None
-        return df
+        today = pd.Timestamp.now(tz=self.iso.default_timezone)
+        assert (df["Time"].dt.date == today.date()).all()
 
     """get_load_forecast"""
 

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -86,27 +86,6 @@ class TestErcot(BaseTestISO):
         assert df.columns.tolist() == cols
         assert df["Time"].unique()[0].date() == three_days_ago
 
-    def test_get_load_latest(self):
-        load = super().test_get_load_latest()
-        expected_keys = {
-            "time",
-            "load",
-        }
-        today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
-        assert load.keys() == expected_keys
-        assert load["time"].date() == today
-
-    def test_get_load_today(self):
-        df = super().test_get_load_today()
-        cols = [
-            "Time",
-            "Load",
-        ]
-        today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
-        assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
-        assert df["Time"].unique()[0].date() == today
-
     """get_load_forecast"""
 
     def test_get_load_forecast_historical(self):

--- a/gridstatus/tests/test_spp.py
+++ b/gridstatus/tests/test_spp.py
@@ -106,28 +106,13 @@ class TestSPP(BaseTestISO):
             (Markets.REAL_TIME_5_MIN, "Hub"),
         ],
     )
-    def test_get_lmp_today2(self, market, location_type):
+    def test_get_lmp_today_with_location(self, market, location_type):
         df = self.iso.get_lmp(
             date="today",
             market=market,
             location_type=location_type,
         )
-        cols = [
-            "Time",
-            "Market",
-            "Location",
-            "Location Type",
-            "LMP",
-            "Energy",
-            "Congestion",
-            "Loss",
-        ]
-        assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
-        markets = df["Market"].unique()
-        assert len(markets) == 1
-        assert markets[0] == market.value
-
+        BaseTestISO._check_lmp_columns(df, market=market)
         location_types = df["Location Type"].unique()
         assert len(location_types) == 1
         assert location_types[0] == location_type

--- a/gridstatus/tests/test_spp.py
+++ b/gridstatus/tests/test_spp.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 import gridstatus
-from gridstatus import SPP, Markets, NotSupported, utils
+from gridstatus import SPP, Markets, NotSupported
 from gridstatus.tests.base_test_iso import BaseTestISO
 
 
@@ -176,14 +176,6 @@ class TestSPP(BaseTestISO):
     def test_get_load_historical(self):
         with pytest.raises(NotSupported):
             super().test_get_load_historical()
-
-    def test_get_load_today(self):
-        df = super().test_get_load_today()
-        today = utils._handle_date(
-            "today",
-            self.iso.default_timezone,
-        )
-        assert (df["Time"].dt.date == today.date()).all()
 
     @pytest.mark.skip(reason="Not Applicable")
     def test_get_load_historical_with_date_range(self):


### PR DESCRIPTION
Remove redundant tests that became clear from #130. 

Move the extra checks to the base function so all ISO benefit 
