### PR TITLE
Enable PJM Realtime Markets

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -253,18 +253,12 @@ class PJM(ISOBase):
 
         if date == "latest":
             """Currently only supports DAY_AHEAD_HOURlY"""
-            if market != Markets.DAY_AHEAD_HOURLY:
-                raise NotImplementedError("Only supports DAY_AHEAD_HOURLY")
             return self._latest_lmp_from_today(
                 market=market,
                 locations=locations,
                 location_type=location_type,
                 verbose=verbose,
             )
-
-        elif utils.is_today(date, tz=self.default_timezone):
-            if market != Markets.DAY_AHEAD_HOURLY:
-                raise NotImplementedError("Only supports DAY_AHEAD_HOURLY")
 
         if locations == "hubs":
             locations = self.hub_node_ids

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -45,15 +45,27 @@ class TestPJM(BaseTestISO):
 
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
+        Markets.REAL_TIME_HOURLY,
+        Markets.REAL_TIME_5_MIN,
     )
     def test_get_lmp_latest(self, market):
-        super().test_get_lmp_latest(market=market)
+        if market in [Markets.REAL_TIME_5_MIN, Markets.REAL_TIME_HOURLY]:
+            with pytest.raises(RuntimeError, match="No data found for query"):
+                super().test_get_lmp_latest(market=market)
+        else:
+            super().test_get_lmp_latest(market=market)
 
     @with_markets(
         Markets.DAY_AHEAD_HOURLY,
+        Markets.REAL_TIME_HOURLY,
+        Markets.REAL_TIME_5_MIN,
     )
     def test_get_lmp_today(self, market):
-        super().test_get_lmp_today(market=market)
+        if market in [Markets.REAL_TIME_5_MIN, Markets.REAL_TIME_HOURLY]:
+            with pytest.raises(RuntimeError, match="No data found for query"):
+                super().test_get_lmp_today(market=market)
+        else:
+            super().test_get_lmp_today(market=market)
 
     def test_get_lmp_no_data(self):
         # raise no error since date in future


### PR DESCRIPTION
Enables PJM realtime markets for today and latest, even though gridstatus cannot current access the data since PJM publishes it with delay. 