### PR TITLE
@lmp_config Decorator

### DIFF
--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -243,7 +243,6 @@ class CAISO(ISOBase):
         # todo make sure defaults to local timezone
         start, end = _caiso_handle_start_end(date, end)
 
-        market = Markets(market)
         if market == Markets.DAY_AHEAD_HOURLY:
             query_name = "PRC_LMP"
             market_run_id = "DAM"

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -10,6 +10,7 @@ import tabula
 from gridstatus import utils
 from gridstatus.base import FuelMix, GridStatus, ISOBase, Markets, NotSupported
 from gridstatus.decorators import support_date_range
+from gridstatus.lmp_config import lmp_config
 
 _BASE = "https://www.caiso.com/outlook/SP"
 _HISTORY_BASE = "https://www.caiso.com/outlook/SP/History"
@@ -196,6 +197,13 @@ class CAISO(ISOBase):
         )
         return df
 
+    @lmp_config(
+        supports={
+            Markets.DAY_AHEAD_HOURLY: ["latest", "today", "historical"],
+            Markets.REAL_TIME_15_MIN: ["latest", "today", "historical"],
+            Markets.REAL_TIME_5_MIN: ["latest", "today", "historical"],
+        },
+    )
     @support_date_range(frequency="31D")
     def get_lmp(
         self,

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -16,6 +16,7 @@ from gridstatus.base import (
     NotSupported,
 )
 from gridstatus.decorators import support_date_range
+from gridstatus.lmp_config import lmp_config
 
 LOCATION_TYPE_HUB = "HUB"
 LOCATION_TYPE_NODE = "NODE"
@@ -532,6 +533,12 @@ class Ercot(ISOBase):
 
         return queue
 
+    @lmp_config(
+        supports={
+            Markets.REAL_TIME_15_MIN: ["latest", "today", "historical"],
+            Markets.DAY_AHEAD_HOURLY: ["latest", "today", "historical"],
+        },
+    )
     @support_date_range(frequency="1D")
     def get_spp(
         self,

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -560,9 +560,6 @@ class Ercot(ISOBase):
             - ``hub``
             - ``node``
         """
-        assert market is not None, "market must be specified"
-        market = Markets(market)
-
         if market == Markets.REAL_TIME_15_MIN:
             df = self._get_spp_rtm15(
                 date,

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -216,7 +216,6 @@ class ISONE(ISOBase):
         """  # noqa
         if locations is None:
             locations = "ALL"
-        market = Markets(market)
         if market == Markets.REAL_TIME_5_MIN:
             url = "https://www.iso-ne.com/transform/csv/fiveminlmp/current?type=prelim"  # noqa
             data = _make_request(url, skiprows=[0, 1, 2, 4], verbose=verbose)
@@ -278,7 +277,6 @@ class ISONE(ISOBase):
             locations = "ALL"
 
         now = pd.Timestamp.now(tz=self.default_timezone)
-        market = Markets(market)
         if market == Markets.REAL_TIME_5_MIN:
             # todo handle intervals for current day
             intervals = ["00-04", "04-08", "08-12", "12-16", "16-20", "20-24"]

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -15,6 +15,7 @@ from gridstatus.base import (
     NotSupported,
 )
 from gridstatus.decorators import support_date_range
+from gridstatus.lmp_config import lmp_config
 
 
 class ISONE(ISOBase):
@@ -242,6 +243,13 @@ class ISONE(ISOBase):
         )
         return data
 
+    @lmp_config(
+        supports={
+            Markets.REAL_TIME_5_MIN: ["latest", "today", "historical"],
+            Markets.REAL_TIME_HOURLY: ["latest", "today", "historical"],
+            Markets.DAY_AHEAD_HOURLY: ["today", "historical"],
+        },
+    )
     @support_date_range(frequency="1D")
     def get_lmp(
         self,

--- a/gridstatus/lmp_config.py
+++ b/gridstatus/lmp_config.py
@@ -1,0 +1,152 @@
+import functools
+
+import pandas as pd
+
+from gridstatus.base import ISOBase, Markets, NotSupported
+from gridstatus.utils import _handle_date, is_today
+
+
+class lmp_config:
+    def __init__(self, supports, tz=None):
+        self.supports = supports
+        self.tz = tz
+
+    def __call__(self, func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if self._is_class_method(args, kwargs):
+                instance = args[0]
+                func_args = args[1:]
+                func_kwargs = kwargs
+                func_sig = self._parse_signature(
+                    instance,
+                    func_args,
+                    func_kwargs,
+                    tz=self.tz,
+                )
+                return self._class_method_wrapper(instance, func, func_sig)
+            else:
+                func_sig = self._parse_signature(None, args, kwargs, tz=self.tz)
+                return self._function_wrapper(func, func_sig)
+
+        return wrapper
+
+    @staticmethod
+    def _is_class_method(args, kwargs):
+        # args[0] must be "self" and an instance of ISOBase
+        return len(args) > 0 and isinstance(args[0], ISOBase)
+
+    @staticmethod
+    def _validate_market_arg_signature(market):
+        return isinstance(market, str) or isinstance(market, Markets)
+
+    @staticmethod
+    def _parse_date(date, tz):
+        if date in (
+            "latest",
+            "today",
+        ):
+            return _handle_date("today", tz=tz)
+        elif isinstance(date, pd.Timestamp):
+            final_date = _handle_date(date, tz=tz)
+            if not isinstance(final_date, pd.Timestamp):
+                raise ValueError(f"Cannot parse date {repr(date)}")
+            return final_date
+        else:
+            raise ValueError("date must be string or pd.Timestamp")
+
+    @staticmethod
+    def _class_method_wrapper(instance, func, func_sig):
+        instance_args = tuple([instance] + list(func_sig["args"]))
+        instance_kwargs = func_sig["kwargs"]
+        return func(*instance_args, **instance_kwargs)
+
+    @staticmethod
+    def _function_wrapper(func, func_sig):
+        return func(*func_sig["args"], **func_sig["kwargs"])
+
+    @staticmethod
+    def _parse_market(market):
+        return Markets(market)
+
+    def _parse_signature(self, instance, args, kwargs, tz):
+        date = None
+        market = None
+
+        if tz is None:
+            if instance is not None:
+                if not hasattr(instance, "default_timezone"):
+                    raise ValueError(
+                        "ISO does not have default_timezone set; cannot determine tz",
+                    )
+                else:
+                    tz = instance.default_timezone
+        if tz is None:
+            raise ValueError("Must set tz= arg or ISO default timezone")
+
+        args = list(args)
+
+        if len(args) == 0:
+            if "date" not in kwargs or "market" not in kwargs:
+                raise ValueError("date and market are required")
+            date = kwargs["date"]
+            market = kwargs["market"]
+        elif len(args) == 1:
+            if "date" in kwargs and "market" in kwargs:
+                date = kwargs["date"]
+                market = kwargs["market"]
+            elif "date" in kwargs:
+                date = kwargs["date"]
+                market = args[0]
+            elif "market" in kwargs:
+                date = args[0]
+                market = kwargs["market"]
+            else:
+                raise ValueError("Missing date or market")
+        else:
+            date = args[0]
+            market = args[1]
+
+        original_date_arg = date
+        date = self._parse_date(date, tz=tz)
+        market = self._parse_market(market)
+
+        self._check_support(original_date_arg, date, market, tz)
+
+        if len(args) == 0:
+            kwargs["date"] = date
+            kwargs["market"] = market
+        elif len(args) == 1:
+            if "date" in kwargs and "market" not in kwargs:
+                kwargs["date"] = date
+                args[0] = market
+            elif "date" not in kwargs and "market" in kwargs:
+                args[0] = date
+                kwargs["market"] = market
+        else:
+            args[0] = date
+            args[1] = market
+
+        return {
+            "args": tuple(args),
+            "kwargs": kwargs,
+        }
+
+    def _check_support(self, original_date_arg, date_arg, market_arg, tz):
+        if market_arg not in self.supports:
+            raise NotSupported(f"{market_arg} not supported")
+
+        if original_date_arg in (
+            "latest",
+            "today",
+        ):
+            supported = original_date_arg in self.supports[market_arg]
+        elif is_today(date_arg, tz):
+            supported = "today" in self.supports[market_arg]
+        else:
+            supported = "historical" in self.supports[market_arg]
+
+        if not supported:
+            raise NotSupported(
+                f"{market_arg} does not support {repr(original_date_arg)}",
+            )

--- a/gridstatus/lmp_config.py
+++ b/gridstatus/lmp_config.py
@@ -67,6 +67,7 @@ class lmp_config:
 
     def _parse_signature(self, instance, args, kwargs, tz):
         date = None
+        date_field = None
         market = None
 
         if tz is None:
@@ -83,16 +84,27 @@ class lmp_config:
         args = list(args)
 
         if len(args) == 0:
-            if "date" not in kwargs or "market" not in kwargs:
-                raise ValueError("date and market are required")
-            date = kwargs["date"]
+            if (
+                "date" not in kwargs and "start" not in kwargs
+            ) or "market" not in kwargs:
+                raise ValueError("date/start and market are required")
+            if "date" in kwargs:
+                date_field = "date"
+            else:
+                date_field = "start"
+            date = kwargs[date_field]
             market = kwargs["market"]
         elif len(args) == 1:
-            if "date" in kwargs and "market" in kwargs:
-                date = kwargs["date"]
+            if ("date" in kwargs or "start" in kwargs) and "market" in kwargs:
+                if "date" in kwargs:
+                    date_field = "date"
+                else:
+                    date_field = "start"
+                date = kwargs[date_field]
                 market = kwargs["market"]
             elif "date" in kwargs:
-                date = kwargs["date"]
+                date_field = "start"
+                date = kwargs[date_field]
                 market = args[0]
             elif "market" in kwargs:
                 date = args[0]
@@ -113,14 +125,14 @@ class lmp_config:
 
         if len(args) == 0:
             if modify_date_arg:
-                kwargs["date"] = date
+                kwargs[date_field] = date
             kwargs["market"] = market
         elif len(args) == 1:
-            if "date" in kwargs and "market" not in kwargs:
+            if date_field in kwargs and "market" not in kwargs:
                 if modify_date_arg:
-                    kwargs["date"] = date
+                    kwargs[date_field] = date
                 args[0] = market
-            elif "date" not in kwargs and "market" in kwargs:
+            elif date_field not in kwargs and "market" in kwargs:
                 if modify_date_arg:
                     args[0] = date
                 kwargs["market"] = market

--- a/gridstatus/lmp_config.py
+++ b/gridstatus/lmp_config.py
@@ -3,7 +3,6 @@ import functools
 import pandas as pd
 
 from gridstatus.base import ISOBase, Markets, NotSupported
-from gridstatus.utils import _handle_date, is_today
 
 
 class lmp_config:
@@ -42,13 +41,10 @@ class lmp_config:
 
     @staticmethod
     def _parse_date(date, tz):
-        if date in (
-            "latest",
-            "today",
-        ):
-            return _handle_date("today", tz=tz)
-        elif isinstance(date, pd.Timestamp):
-            final_date = _handle_date(date, tz=tz)
+        if date == "latest":
+            return lmp_config.__handle_date("today", tz=tz)
+        elif isinstance(date, str) or isinstance(date, pd.Timestamp):
+            final_date = lmp_config.__handle_date(date, tz=tz)
             if not isinstance(final_date, pd.Timestamp):
                 raise ValueError(f"Cannot parse date {repr(date)}")
             return final_date
@@ -141,7 +137,7 @@ class lmp_config:
             "today",
         ):
             supported = original_date_arg in self.supports[market_arg]
-        elif is_today(date_arg, tz):
+        elif lmp_config.__is_today(date_arg, tz):
             supported = "today" in self.supports[market_arg]
         else:
             supported = "historical" in self.supports[market_arg]
@@ -150,3 +146,25 @@ class lmp_config:
             raise NotSupported(
                 f"{market_arg} does not support {repr(original_date_arg)}",
             )
+
+    # copied from utils.py to avoid circular import
+    @staticmethod
+    def __handle_date(date, tz=None):
+        if date == "today":
+            date = pd.Timestamp.now(tz=tz)
+
+        if not isinstance(date, pd.Timestamp):
+            date = pd.to_datetime(date)
+
+        if tz and date.tzinfo is None:
+            date = date.tz_localize(tz)
+
+        return date
+
+    # copied from utils.py to avoid circular import
+    @staticmethod
+    def __is_today(date, tz):
+        return (
+            lmp_config.__handle_date(date, tz=tz).date()
+            == pd.Timestamp.now(tz=tz).date()
+        )

--- a/gridstatus/lmp_config.py
+++ b/gridstatus/lmp_config.py
@@ -1,3 +1,4 @@
+import datetime
 import functools
 
 import pandas as pd
@@ -43,13 +44,20 @@ class lmp_config:
     def _parse_date(date, tz):
         if date == "latest":
             return lmp_config.__handle_date("today", tz=tz)
-        elif isinstance(date, str) or isinstance(date, pd.Timestamp):
+        elif (
+            isinstance(date, str)
+            or isinstance(date, pd.Timestamp)
+            or isinstance(date, datetime.date)
+        ):
             final_date = lmp_config.__handle_date(date, tz=tz)
             if not isinstance(final_date, pd.Timestamp):
                 raise ValueError(f"Cannot parse date {repr(date)}")
             return final_date
         else:
-            raise ValueError("date must be string or pd.Timestamp")
+            raise ValueError(
+                "date must be string or pd.Timestamp: "
+                f"{repr(date)} of type ({type(date)})",
+            )
 
     @staticmethod
     def _class_method_wrapper(instance, func, func_sig):

--- a/gridstatus/lmp_config.py
+++ b/gridstatus/lmp_config.py
@@ -109,18 +109,24 @@ class lmp_config:
 
         self._check_support(original_date_arg, date, market, tz)
 
+        modify_date_arg = original_date_arg != "latest"
+
         if len(args) == 0:
-            kwargs["date"] = date
+            if modify_date_arg:
+                kwargs["date"] = date
             kwargs["market"] = market
         elif len(args) == 1:
             if "date" in kwargs and "market" not in kwargs:
-                kwargs["date"] = date
+                if modify_date_arg:
+                    kwargs["date"] = date
                 args[0] = market
             elif "date" not in kwargs and "market" in kwargs:
-                args[0] = date
+                if modify_date_arg:
+                    args[0] = date
                 kwargs["market"] = market
         else:
-            args[0] = date
+            if modify_date_arg:
+                args[0] = date
             args[1] = market
 
         return {

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -5,6 +5,7 @@ import requests
 
 from gridstatus import utils
 from gridstatus.base import FuelMix, ISOBase, Markets, NotSupported
+from gridstatus.lmp_config import lmp_config
 
 
 class MISO(ISOBase):
@@ -126,6 +127,12 @@ class MISO(ISOBase):
         r = self._get_json(url, verbose=verbose)
         return r
 
+    @lmp_config(
+        supports={
+            Markets.REAL_TIME_5_MIN: ["latest"],
+            Markets.DAY_AHEAD_HOURLY: ["latest"],
+        },
+    )
     def get_lmp(self, date, market: str, locations: list = None, verbose=False):
         """
         Supported Markets:

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -152,7 +152,6 @@ class MISO(ISOBase):
         time_str = time[:11] + " " + time[-9:]
         time = pd.to_datetime(time_str).tz_localize("EST")
 
-        market = Markets(market)
         if market == Markets.REAL_TIME_5_MIN:
             data = pd.DataFrame(r["LMPData"]["FiveMinLMP"]["PricingNode"])
         elif market == Markets.DAY_AHEAD_HOURLY:

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -14,6 +14,7 @@ from gridstatus.base import (
     Markets,
 )
 from gridstatus.decorators import support_date_range
+from gridstatus.lmp_config import lmp_config
 
 ZONE = "zone"
 GENERATOR = "generator"
@@ -162,6 +163,12 @@ class NYISO(ISOBase):
 
         return data
 
+    @lmp_config(
+        supports={
+            Markets.REAL_TIME_5_MIN: ["latest", "today", "historical"],
+            Markets.DAY_AHEAD_HOURLY: ["latest", "today", "historical"],
+        },
+    )
     @support_date_range(frequency="MS")
     def get_lmp(
         self,

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -202,8 +202,6 @@ class NYISO(ISOBase):
         if location_type is None:
             location_type = ZONE
 
-        assert market is not None, "market must be specified"
-        market = Markets(market)
         marketname = self._set_marketname(market)
         location_type = self._set_location_type(location_type)
         filename = marketname + f"_{location_type}"

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -13,6 +13,7 @@ from gridstatus.decorators import (
     pjm_update_dates,
     support_date_range,
 )
+from gridstatus.lmp_config import lmp_config
 
 
 class PJM(ISOBase):
@@ -203,6 +204,13 @@ class PJM(ISOBase):
         )
         return nodes
 
+    @lmp_config(
+        supports={
+            Markets.REAL_TIME_5_MIN: ["today", "historical"],
+            Markets.REAL_TIME_HOURLY: ["today", "historical"],
+            Markets.DAY_AHEAD_HOURLY: ["latest", "today", "historical"],
+        },
+    )
     @support_date_range(frequency="365D", update_dates=pjm_update_dates)
     def get_lmp(
         self,

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -257,8 +257,6 @@ class PJM(ISOBase):
                 'HUB', 'EHV', 'TIE', 'RESIDUAL_METERED_EDC'.
 
         """
-        market = Markets(market)
-
         if date == "latest":
             """Currently only supports DAY_AHEAD_HOURlY"""
             return self._latest_lmp_from_today(

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -18,6 +18,7 @@ from gridstatus.base import (
     NotSupported,
 )
 from gridstatus.decorators import support_date_range
+from gridstatus.lmp_config import lmp_config
 
 FS_RTBM_LMP_BY_LOCATION = "rtbm-lmp-by-location"
 FS_DAM_LMP_BY_LOCATION = "da-lmp-by-location"
@@ -295,6 +296,12 @@ class SPP(ISOBase):
 
         return queue
 
+    @lmp_config(
+        supports={
+            Markets.REAL_TIME_5_MIN: ["latest", "today", "historical"],
+            Markets.DAY_AHEAD_HOURLY: ["latest", "today", "historical"],
+        },
+    )
     @support_date_range(frequency="1D")
     def get_lmp(
         self,

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -323,7 +323,6 @@ class SPP(ISOBase):
             - ``interface``
             - ``settlement_location``
         """
-        market = Markets(market)
         if market not in self.markets:
             raise NotSupported(f"Market {market} not supported")
         location_type = self._normalize_location_type(location_type)

--- a/gridstatus/tests/test_lmp_config.py
+++ b/gridstatus/tests/test_lmp_config.py
@@ -1,0 +1,114 @@
+import pandas as pd
+import pytest
+
+from gridstatus.base import ISOBase, Markets, NotSupported
+from gridstatus.lmp_config import lmp_config
+
+
+def days_ago(days):
+    return pd.Timestamp.now(
+        tz=ISOTodayHistoricalDayAheadHourly.default_timezone,
+    ) - pd.Timedelta(days=days)
+
+
+class ISOZeroSupport(ISOBase):
+    default_timezone = "US/Central"
+
+    @lmp_config(supports={})
+    def get_lmp(self, date, market):
+        print(f"get_lmp({date}, {market})")
+
+
+@lmp_config(supports={}, tz="US/Central")
+def zero_support_get_lmp(self, date, market):
+    print(f"get_lmp({date}, {market})")
+
+
+class ISOTodayHistoricalDayAheadHourly(ISOBase):
+    default_timezone = "US/Central"
+
+    @lmp_config(supports={Markets.DAY_AHEAD_HOURLY: ["today", "historical"]})
+    def get_lmp(self, date, market):
+        print(f"get_lmp({date}, {market})")
+
+
+@lmp_config(
+    supports={Markets.DAY_AHEAD_HOURLY: ["today", "historical"]},
+    tz="US/Central",
+)
+def today_historical_day_ahead_hourly_get_lmp(date, market):
+    print(f"get_lmp({date}, {market})")
+
+
+class ISOLatestRealTime15Minutes(ISOBase):
+    default_timezone = "US/Central"
+
+    @lmp_config(supports={Markets.REAL_TIME_15_MIN: ["latest"]})
+    def get_lmp(self, date, market):
+        print(f"get_lmp({date}, {market})")
+
+
+@lmp_config(supports={Markets.REAL_TIME_15_MIN: ["latest"]}, tz="US/Central")
+def latest_real_time_15_min_get_lmp(date, market):
+    print(f"get_lmp({date}, {market})")
+
+
+def test_lmp_config_support_check_matches():
+    iso = ISOLatestRealTime15Minutes()
+    iso.get_lmp("latest", Markets.REAL_TIME_15_MIN)
+    latest_real_time_15_min_get_lmp("latest", Markets.REAL_TIME_15_MIN)
+    iso.get_lmp("latest", "REAL_TIME_15_MIN")
+    latest_real_time_15_min_get_lmp("latest", "REAL_TIME_15_MIN")
+
+    iso = ISOTodayHistoricalDayAheadHourly()
+    iso.get_lmp("today", Markets.DAY_AHEAD_HOURLY)
+    today_historical_day_ahead_hourly_get_lmp("today", Markets.DAY_AHEAD_HOURLY)
+    iso.get_lmp("today", "DAY_AHEAD_HOURLY")
+    today_historical_day_ahead_hourly_get_lmp("today", "DAY_AHEAD_HOURLY")
+    iso.get_lmp(days_ago(2), Markets.DAY_AHEAD_HOURLY)
+    today_historical_day_ahead_hourly_get_lmp(days_ago(2), Markets.DAY_AHEAD_HOURLY)
+    iso.get_lmp(days_ago(2), "DAY_AHEAD_HOURLY")
+    today_historical_day_ahead_hourly_get_lmp(days_ago(2), "DAY_AHEAD_HOURLY")
+
+
+def test_lmp_config_signature_combos_success():
+    iso = ISOLatestRealTime15Minutes()
+    date = "latest"
+    market = "REAL_TIME_15_MIN"
+    iso.get_lmp(date, market)
+    iso.get_lmp(date, market=market)
+    iso.get_lmp(date=date, market=market)
+
+
+def test_lmp_config_signature_combos_failure():
+    iso = ISOLatestRealTime15Minutes()
+    date = "latest"
+    market = "REAL_TIME_15_MIN"
+
+    with pytest.raises(ValueError):
+        iso.get_lmp(date)
+    with pytest.raises(ValueError):
+        iso.get_lmp(market)
+    with pytest.raises(ValueError):
+        iso.get_lmp(date=date)
+    with pytest.raises(ValueError):
+        iso.get_lmp(market=market)
+    with pytest.raises(ValueError):
+        latest_real_time_15_min_get_lmp(date)
+    with pytest.raises(ValueError):
+        latest_real_time_15_min_get_lmp(market)
+    with pytest.raises(ValueError):
+        latest_real_time_15_min_get_lmp(date=date)
+    with pytest.raises(ValueError):
+        latest_real_time_15_min_get_lmp(market=market)
+
+
+def test_lmp_config_support_check_does_not_match():
+    with pytest.raises(NotSupported):
+        ISOTodayHistoricalDayAheadHourly().get_lmp("latest", Markets.DAY_AHEAD_HOURLY)
+    with pytest.raises(NotSupported):
+        today_historical_day_ahead_hourly_get_lmp("latest", Markets.DAY_AHEAD_HOURLY)
+    with pytest.raises(NotSupported):
+        ISOZeroSupport().get_lmp("today", Markets.DAY_AHEAD_HOURLY)
+    with pytest.raises(NotSupported):
+        zero_support_get_lmp("today", Markets.DAY_AHEAD_HOURLY)

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -50,7 +50,7 @@ class TestPJM(BaseTestISO):
     )
     def test_get_lmp_latest(self, market):
         if market in [Markets.REAL_TIME_5_MIN, Markets.REAL_TIME_HOURLY]:
-            with pytest.raises(RuntimeError, match="No data found for query"):
+            with pytest.raises(NotSupported):
                 super().test_get_lmp_latest(market=market)
         else:
             super().test_get_lmp_latest(market=market)


### PR DESCRIPTION
Quality of life improvement: declarative market and date (`latest`, `today`, `historical`) support for `get_lmp`/`get_spp`.

This will enforce args/kwargs presence of `date` (or `start`, from `@support_date_range`) and `market`.

`lmp_config.supports` also gives us an imperative way to check the config:

```python
import gridstatus
from gridstatus import Markets
from gridstatus.lmp_config import lmp_config

if lmp_config.supports(
    gridstatus.CAISO.get_lmp, Markets.REAL_TIME_5_MIN, "latest"):
    print("CAISO supports REAL_TIME_5_MIN")
```

The `make_lmp_availability_df` and table method can/should probably be rewritten to provide a more granular breakdown of what's all supported.

### Considerations

* Could live in `decorators.py`
* Could be named something else... `market_date_config`
* Or, it could be specialized for `get_lmp`/`get_spp` and do other things later such as:
  * `location_type` filtering
  * automatic wrapping `date=latest` with `_latest_lmp_from_today`

### Unknown

* Don't know how it interacts with `@support_date_range`, other than having to add `start=` support.