### PR TITLE
Make sure isone gets latest interconnection queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v0.18.0
+## vNext
+
+- Updated ISONE Interconnection Queue to contain completed and withdrawn projects
+
+## v0.18.0 - Jan 27, 2023
 
 - Update CAISO LMP markets to support real time five minute
 - Fix bug affecting NYISO interconnection queues

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -1,5 +1,6 @@
 import io
 import math
+import re
 import sys
 
 import pandas as pd
@@ -481,9 +482,18 @@ class ISONE(ISOBase):
             pandas.DataFrame: interconnection queue
 
         """  # noqa
-        # not sure what the reportdate value is.
-        # it is hardcode into the javascript to add and doesnt work without
-        url = "https://irtt.iso-ne.com/reports/exportpublicqueue?ReportDate=638005248000000000&Status=&Jurisdiction="  # noqa
+
+        # determine report date from homepage
+        if verbose:
+            print("Loading report date from", self.interconnection_homepage)
+        c = requests.get(self.interconnection_homepage)
+        match = re.search(
+            r"url \+ '\?ReportDate=' \+ ([0-9]+) \+ '&Status='",
+            c.text,
+        )
+        report_date = match.group(1)
+
+        url = f"https://irtt.iso-ne.com/reports/exportpublicqueue?ReportDate={report_date}&Status=&Jurisdiction="  # noqa
 
         if verbose:
             print("Loading interconnection queue from {}".format(url))

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -207,6 +207,9 @@ def format_interconnection_df(queue, rename, extra=None, missing=None):
     columns = _interconnection_columns.copy()
 
     if extra:
+        for e in extra:
+            assert e in queue.columns, f"Extra column {e} does not exist"
+
         columns += extra
 
     if missing:


### PR DESCRIPTION
Use HTML table directly rather than export.

This allows us to get completed and withdrawn projects as well. 