### PR TITLE
Ercot historial ancillary

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -630,6 +630,18 @@ class Ercot(ISOBase):
 
         data.rename(columns=rename, inplace=True)
 
+        # redorder to match other ancillary function
+        col_order = [
+            "Time",
+            "Market",
+            "Non-Spinning Reserves",
+            "Regulation Down",
+            "Regulation Up",
+            "Responsive Reserves",
+        ]
+
+        data = data[col_order].copy()
+
         return data
 
     def _get_spp_dam(

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -32,6 +32,30 @@ class TestErcot(BaseTestISO):
         assert df.columns.tolist() == as_cols
         assert df["Time"].unique()[0].date() == date
 
+    def test_get_as_prices_historical(self):
+        as_cols = [
+            "Time",
+            "Market",
+            "Non-Spinning Reserves",
+            "Regulation Down",
+            "Regulation Up",
+            "Responsive Reserves",
+        ]
+
+        year = 2019
+        first_date = pd.Timestamp(year, 1, 1).date()
+        df = self.iso.get_as_prices_historical(year)
+        assert df.shape[0] >= 0
+        assert df.columns.tolist() == as_cols
+        assert df["Time"].unique()[0].date() == first_date
+
+        year = year - 1
+        first_date = pd.Timestamp(year, 1, 1).date()
+        df = self.iso.get_as_prices_historical(year)
+        assert df.shape[0] >= 0
+        assert df.columns.tolist() == as_cols
+        assert df["Time"].unique()[0].date() == first_date
+
     """get_fuel_mix"""
 
     def test_get_fuel_mix(self):


### PR DESCRIPTION
#154 

Adding support to pull ERCOT annual historial ancillary prices. The exiting functionality in `get_as_prices` supports single date up to t-30days. 