### PR TITLE
Update some ISOs fuel mix to instantaneous 

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -148,7 +148,7 @@ class Ercot(ISOBase):
 
         Returns:
             pandas.DataFrame: A DataFrame with columns; Time and columns for each fuel \
-                type (solar and wind)
+                type
         """
 
         if date == "latest":

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -170,25 +170,21 @@ class Ercot(ISOBase):
                 )
                 .T
             )
-            mix.index.name = "Interval End"
+            mix.index.name = "Time"
             mix = mix.reset_index()
 
-            mix["Interval End"] = pd.to_datetime(mix["Interval End"]).dt.tz_localize(
+            mix["Time"] = pd.to_datetime(mix["Time"]).dt.tz_localize(
                 self.default_timezone,
                 ambiguous="infer",
             )
 
             # most timestamps are a few seconds off round 5 minute ticks
             # round to nearest minute
-            mix["Interval End"] = mix["Interval End"].round("min")
-            mix["Interval Start"] = mix["Interval End"] - pd.Timedelta(minutes=5)
-            mix["Time"] = mix["Interval Start"]
+            mix["Time"] = mix["Time"].round("min")
 
             mix = mix[
                 [
                     "Time",
-                    "Interval Start",
-                    "Interval End",
                     "Coal and Lignite",
                     "Hydro",
                     "Nuclear",

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -140,37 +140,15 @@ class ISONE(ISOBase):
         ).reset_index()
         mix_df.columns.name = None
 
-        # assume interval end. unclear based on data
-        mix_df = mix_df.rename(columns={"Date": "Interval End"})
+        # assume instant in time, unclear if this is correct
+        mix_df = mix_df.rename(columns={"Date": "Time"})
 
         mix_df = mix_df.fillna(0)
-
-        mix_df["Interval Start"] = (
-            mix_df["Interval End"] - mix_df["Interval End"].diff()
-        )
-
-        # add midnight to first row of Interval Start
-        mix_df.loc[0, "Interval Start"] = mix_df["Interval Start"].min().normalize()
-
-        # if historical data, add row at end to go to midnight of next day
-        # todo manually verified works, but add test for this
-        if not utils.is_today(date, self.default_timezone):
-            new_row = pd.DataFrame(
-                {
-                    "Interval Start": [mix_df["Interval End"].max()],
-                    "Interval End": [
-                        mix_df["Interval End"].max().normalize() + pd.Timedelta(days=1),
-                    ],
-                },
-            )
-            mix_df = pd.concat([mix_df, new_row], ignore_index=True).ffill()
-
-        mix_df["Time"] = mix_df["Interval Start"]
 
         # move time columns front
         mix_df = utils.move_cols_to_front(
             mix_df,
-            ["Time", "Interval Start", "Interval End"],
+            ["Time"],
         )
 
         return mix_df

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -107,7 +107,19 @@ class NYISO(ISOBase):
 
     @support_date_range(frequency="MS")
     def get_load(self, date, end=None, verbose=False):
-        """Returns load at a previous date in 5 minute intervals"""
+        """Returns load at a previous date in 5 minute intervals for
+          each zone and total load
+
+        Parameters:
+            date (str): Date to get load for. Can be "latest", "today", or
+              a date in the format YYYY-MM-DD
+            end (str): End date for date range. Optional.
+            verbose (bool): Whether to print verbose output. Optional.
+
+        Returns:
+            pandas.DataFrame: Load data for NYISO and each zone
+
+        """
         if date == "latest":
             return self._latest_from_today(self.get_load)
 
@@ -118,17 +130,21 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        # drop NA loads
-        data = data.dropna(subset=["Load"])
-
-        # TODO load by zone
-        load = (
-            data.groupby(["Time", "Interval Start", "Interval End"])["Load"]
-            .sum()
-            .reset_index()
+        # pivot table
+        df = data.pivot_table(
+            index=["Time"],
+            columns="Name",
+            values="Load",
+            aggfunc="first",
         )
 
-        return load
+        df.insert(0, "Load", df.sum(axis=1))
+
+        df.reset_index(inplace=True)
+        # drop NA loads
+        # data = data.dropna(subset=["Load"])
+
+        return df
 
     @support_date_range(frequency="MS")
     def get_load_forecast(self, date, end=None, verbose=False):
@@ -731,7 +747,7 @@ class NYISO(ISOBase):
 dataset_interval_map = {
     # (time_type, interval_duration_minutes)
     # load
-    "pal": ("start", 5),
+    "pal": ("instantaneous", None),
     # fuel mix
     "rtfuelmix": ("instantaneous", None),
     # load forecast

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -95,7 +95,7 @@ class NYISO(ISOBase):
         )
 
         mix_df = mix_df.pivot_table(
-            index=["Time", "Interval Start", "Interval End"],
+            index=["Time"],
             columns="Fuel Category",
             values="Gen MW",
             aggfunc="first",
@@ -733,7 +733,7 @@ dataset_interval_map = {
     # load
     "pal": ("start", 5),
     # fuel mix
-    "rtfuelmix": ("end", 5),
+    "rtfuelmix": ("instantaneous", None),
     # load forecast
     "isolf": ("start", 60),
     # dam lmp
@@ -785,10 +785,11 @@ def _handle_time(df, dataset_name):
         interval_duration = pd.Timedelta(minutes=interval_duration_minutes)
         if time_type == "start":
             df["Interval Start"] = df["Time"]
-            df["Interval End"] = df["Time"] + interval_duration
+            df["Interval End"] = df["Interval Start"] + interval_duration
         elif time_type == "end":
-            df["Interval End"] = df["Time"]
             df["Interval Start"] = df["Time"] - interval_duration
+            df["Interval End"] = df["Time"]
+            df["Time"] = df["Interval Start"]
 
         utils.move_cols_to_front(
             df,

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -220,14 +220,24 @@ class BaseTestISO:
 
     """other"""
 
-    def _check_ordered_by_time(self, df):
+    def _check_ordered_by_time(self, df, col):
         assert isinstance(df, pd.DataFrame)
         assert df.shape[0] > 0
-        assert df["Interval Start"].is_monotonic_increasing
+        assert df[col].is_monotonic_increasing
 
-    def _check_time_columns(self, df):
+    def _check_time_columns(self, df, instant_or_interval="interval"):
         assert isinstance(df, pd.DataFrame)
-        time_cols = ["Time", "Interval Start", "Interval End"]
+
+        if instant_or_interval == "interval":
+            time_cols = ["Time", "Interval Start", "Interval End"]
+            ordered_by_col = "Interval Start"
+        elif instant_or_interval == "instant":
+            time_cols = ["Time"]
+            ordered_by_col = "Time"
+        else:
+            raise ValueError(
+                "instant_or_interval must be 'interval' or 'instant'",
+            )
 
         assert time_cols == df.columns[: len(time_cols)].tolist()
         # check all time cols are localized timestamps
@@ -235,12 +245,20 @@ class BaseTestISO:
             assert isinstance(df.loc[0][col], pd.Timestamp)
             assert df.loc[0][col].tz is not None
 
-        self._check_ordered_by_time(df)
+        self._check_ordered_by_time(df, ordered_by_col)
 
     def _check_fuel_mix(self, df):
         assert isinstance(df, pd.DataFrame)
         assert df.columns.name is None
-        self._check_time_columns(df)
+
+        time_type = "interval"
+        if self.iso.iso_id in ["nyiso", "isone", "ercot"]:
+            time_type = "instant"
+        elif self.iso.iso_id in ["caiso", "spp", "miso", "pjm"]:
+            time_type = "interval"
+        else:
+            raise ValueError("Unknown ISO ID")
+        self._check_time_columns(df, instant_or_interval=time_type)
 
     def _check_load(self, df):
         assert isinstance(df, pd.DataFrame)

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -234,6 +234,8 @@ class BaseTestISO:
         elif instant_or_interval == "instant":
             time_cols = ["Time"]
             ordered_by_col = "Time"
+            assert "Interval Start" not in df.columns
+            assert "Interval End" not in df.columns
         else:
             raise ValueError(
                 "instant_or_interval must be 'interval' or 'instant'",

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -265,7 +265,12 @@ class BaseTestISO:
     def _check_load(self, df):
         assert isinstance(df, pd.DataFrame)
         assert df.shape[0] >= 0
-        self._check_time_columns(df)
+
+        if self.iso.iso_id in ["nyiso"]:
+            time_type = "instant"
+        elif self.iso.iso_id in ["caiso", "isone", "spp", "miso", "pjm", "ercot"]:
+            time_type = "interval"
+        self._check_time_columns(df, instant_or_interval=time_type)
         assert "Load" in df.columns
         assert is_numeric_dtype(df["Load"])
 

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -68,8 +68,6 @@ class TestErcot(BaseTestISO):
         # today
         cols = [
             "Time",
-            "Interval Start",
-            "Interval End",
             "Coal and Lignite",
             "Hydro",
             "Nuclear",

--- a/gridstatus/tests/test_nyiso.py
+++ b/gridstatus/tests/test_nyiso.py
@@ -43,6 +43,27 @@ class TestNYISO(BaseTestISO):
         assert set(df.columns).issuperset(set(columns))
         assert df.shape[0] >= 0
 
+    """get_load"""
+
+    def test_get_load_contains_zones(self):
+        df = self.iso.get_load("today")
+        nyiso_load_cols = [
+            "Time",
+            "Load",
+            "CAPITL",
+            "CENTRL",
+            "DUNWOD",
+            "GENESE",
+            "HUD VL",
+            "LONGIL",
+            "MHK VL",
+            "MILLWD",
+            "N.Y.C.",
+            "NORTH",
+            "WEST",
+        ]
+        assert df.columns.tolist() == nyiso_load_cols
+
     """get_lmp"""
 
     @with_markets(


### PR DESCRIPTION
Did another review of ISOs fuel mix dataset and some appear to be instantaneous readings rather than average over an interval. 

ERCOT documentation specifically says "point in time" 

In the case where it isn't clear like isone and nyiso, assumed to be instantaneous

