### PR TITLE
Support tuples for date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## vNext
+
+- Date ranges can be provided as either separate start/end arguments or a tuple to date.
+
+```python
+# both do the same thing
+iso.get_load(start="Jan 1, 2023", end="March 1, 2023")
+iso.get_load(date=("Jan 1, 2023", "March 1, 2023"))
+```
+
 ## v0.20.0 - March 24, 2023
 
 - Add `Interval Start` and `Interval End` time stamps to every applicable time series to avoid ambiguity. The `Time` column will be dropped in favor of just these two columns in next release

--- a/gridstatus/decorators.py
+++ b/gridstatus/decorators.py
@@ -39,8 +39,8 @@ class support_date_range:
             if "error" in args_dict:
                 error = args_dict.pop("error")
 
-            # if date is a tuple/list, then change to start and end
-            if "date" in args_dict and isinstance(args_dict["date"], (list, tuple)):
+            # if date is a tuple, then change to start and end
+            if "date" in args_dict and isinstance(args_dict["date"], tuple):
                 args_dict["start"] = args_dict["date"][0]
                 args_dict["end"] = args_dict["date"][1]
                 del args_dict["date"]

--- a/gridstatus/decorators.py
+++ b/gridstatus/decorators.py
@@ -39,6 +39,12 @@ class support_date_range:
             if "error" in args_dict:
                 error = args_dict.pop("error")
 
+            # if date is a tuple/list, then change to start and end
+            if "date" in args_dict and isinstance(args_dict["date"], (list, tuple)):
+                args_dict["start"] = args_dict["date"][0]
+                args_dict["end"] = args_dict["date"][1]
+                del args_dict["date"]
+
             if "date" in args_dict and "start" in args_dict:
                 raise ValueError(
                     "Cannot supply both 'date' and 'start' to function {}".format(

--- a/gridstatus/lmp_config.py
+++ b/gridstatus/lmp_config.py
@@ -37,6 +37,10 @@ class lmp_config:
         to be used later on for validation"""
         from gridstatus.utils import _handle_date
 
+        # if date range tuple, just validate start
+        if isinstance(date, tuple):
+            date = date[0]
+
         if date == "latest":
             return _handle_date("today", tz=tz)
         elif (

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -140,7 +140,7 @@ class BaseTestISO:
         # make sure right number of days are returned
         assert data["Time"].dt.day.nunique() == num_days
 
-        data_tuple = self.iso.get_load(date=[start.date(), end.date()])
+        data_tuple = self.iso.get_load(date=(start.date(), end.date()))
 
         assert data_tuple.equals(data)
 

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -129,15 +129,20 @@ class BaseTestISO:
     """get_load"""
 
     def test_get_load_historical_with_date_range(self):
-        num_days = 7
+        num_days = 4
         end = pd.Timestamp.now(
             tz=self.iso.default_timezone,
         ) + pd.Timedelta(days=1)
         start = end - pd.Timedelta(days=num_days)
+
         data = self.iso.get_load(date=start.date(), end=end.date())
         self._check_load(data)
         # make sure right number of days are returned
         assert data["Time"].dt.day.nunique() == num_days
+
+        data_tuple = self.iso.get_load(date=[start.date(), end.date()])
+
+        assert data_tuple.equals(data)
 
     def test_get_load_historical(self):
         # pick a test date 2 weeks back


### PR DESCRIPTION
Date ranges can be provided as either separate start/end arguments or a tuple to date. 

```
iso.get_load(start="Jan 1, 2023", end="March 1, 2023")
iso.get_load(date=("Jan 1, 2023", "March 1, 2023"))
```