### PR TITLE
SPP ver curtailments

### DIFF
--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -294,6 +294,8 @@ class SPP(ISOBase):
 
         df = self._process_ver_curtailments(df)
 
+        df = df[~df["Interval Start"].isnull()]
+
         df = df.sort_values("Time")
 
         return df

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -248,7 +248,7 @@ class SPP(ISOBase):
         return df
 
     @support_date_range("DAY_START")
-    def get_ver_curtailments(self, date, end=None, verbose=True):
+    def get_ver_curtailments(self, date, end=None, verbose=False):
         """Get VER Curtailments
 
         Supports recent data. For historical annual data use get_ver_curtailments_annual
@@ -259,7 +259,7 @@ class SPP(ISOBase):
 
 
         """
-        url = f"https://marketplace.spp.org/file-browser-api/download/ver-curtailments?path=%2F2023%2F05%2FVER-Curtailments-{date.strftime('%Y%m%d')}.csv"  # noqa
+        url = f"https://marketplace.spp.org/file-browser-api/download/ver-curtailments?path=%2F{date.strftime('%Y')}%2F{date.strftime('%m')}%2FVER-Curtailments-{date.strftime('%Y%m%d')}.csv"  # noqa
 
         msg = f"Downloading {url}"
         log(msg, verbose)
@@ -268,6 +268,16 @@ class SPP(ISOBase):
         return self._process_ver_curtailments(df)
 
     def get_ver_curtailments_annual(self, year, verbose=True):
+        """Get VER Curtailments for a year. Starting 2014.
+        Recent data use get_ver_curtailments
+
+        Args:
+            year: year to get data for
+            verbose: print url
+
+        Returns:
+            pd.DataFrame: VER Curtailments
+        """
         url = f"https://marketplace.spp.org/file-browser-api/download/ver-curtailments?path=%2F{year}%2F{year}.zip"  # noqa
         z = utils.get_zip_folder(url, verbose=verbose)
 


### PR DESCRIPTION
```python
>>> import gridstatus
>>> iso = gridstatus.SPP()
>>> iso.get_ver_curtailments("2022-01-01", verbose=True)
Downloading https://marketplace.spp.org/file-browser-api/download/ver-curtailments?path=%2F2022%2F01%2FVER-Curtailments-20220101.csv
                         Time            Interval Start              Interval End  Wind Redispatch Curtailments  Wind Manual Curtailments Wind Curtailed For Energy Solar Redispatch Curtailments Solar Manual Curtailments Solar Curtailed For Energy
0   2022-01-01 00:00:00-06:00 2022-01-01 00:00:00-06:00 2022-01-01 00:05:00-06:00                       2727.82                    233.00                       NaN                           NaN                       NaN                        NaN
1   2022-01-01 00:05:00-06:00 2022-01-01 00:05:00-06:00 2022-01-01 00:10:00-06:00                       2709.28                    233.65                       NaN                           NaN                       NaN                        NaN
2   2022-01-01 00:10:00-06:00 2022-01-01 00:10:00-06:00 2022-01-01 00:15:00-06:00                       2845.47                    239.13                       NaN                           NaN                       NaN                        NaN
3   2022-01-01 00:15:00-06:00 2022-01-01 00:15:00-06:00 2022-01-01 00:20:00-06:00                       2686.16                    229.22                       NaN                           NaN                       NaN                        NaN
4   2022-01-01 00:20:00-06:00 2022-01-01 00:20:00-06:00 2022-01-01 00:25:00-06:00                       2566.79                    228.77                       NaN                           NaN                       NaN                        NaN
..                        ...                       ...                       ...                           ...                       ...                       ...                           ...                       ...                        ...
283 2022-01-01 23:35:00-06:00 2022-01-01 23:35:00-06:00 2022-01-01 23:40:00-06:00                       1127.80                    160.47                       NaN                           NaN                       NaN                        NaN
284 2022-01-01 23:40:00-06:00 2022-01-01 23:40:00-06:00 2022-01-01 23:45:00-06:00                       1022.67                    160.41                       NaN                           NaN                       NaN                        NaN
285 2022-01-01 23:45:00-06:00 2022-01-01 23:45:00-06:00 2022-01-01 23:50:00-06:00                        956.67                    152.88                       NaN                           NaN                       NaN                        NaN
286 2022-01-01 23:50:00-06:00 2022-01-01 23:50:00-06:00 2022-01-01 23:55:00-06:00                        827.39                    154.74                       NaN                           NaN                       NaN                        NaN
287 2022-01-01 23:55:00-06:00 2022-01-01 23:55:00-06:00 2022-01-02 00:00:00-06:00                       1117.77                    153.56                       NaN                           NaN                       NaN                        NaN

[288 rows x 9 columns]
```