### PR TITLE
add new ERCOT AS ECRS product support and testing

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -874,7 +874,8 @@ class Ercot(ISOBase):
         Returns:
 
             pandas.DataFrame: A DataFrame with prices for "Non-Spinning Reserves", \
-                "Regulation Up", "Regulation Down", "Responsive Reserves".
+                "Regulation Up", "Regulation Down", "Responsive Reserves", \
+                "ERCOT Contingency Reserve Service"
 
         Source:
             https://www.ercot.com/mp/data-products/data-product-details?id=NP4-181-ER
@@ -934,7 +935,7 @@ class Ercot(ISOBase):
     @support_date_range("DAY_START")
     def _get_as_prices_recent(self, date, verbose=False):
         """Get ancillary service clearing prices in hourly intervals in Day
-            Ahead Market. This function is can return the last 31 days
+            Ahead Market. This function can return the last 31 days
             of ancillary pricing.
 
         Arguments:
@@ -945,7 +946,8 @@ class Ercot(ISOBase):
         Returns:
 
             pandas.DataFrame: A DataFrame with prices for "Non-Spinning Reserves", \
-                "Regulation Up", "Regulation Down", "Responsive Reserves".
+                "Regulation Up", "Regulation Down", "Responsive Reserves", \
+                "ERCOT Contingency Reserve Service"
 
         """
         # subtract one day since it's the day ahead market happens on the day
@@ -988,12 +990,13 @@ class Ercot(ISOBase):
         # some columns from workbook contain trailing/leading whitespace
         doc.columns = [x.strip() for x in doc.columns]
 
-        # NSPIN  REGDN  REGUP  RRS
+        # NSPIN  REGDN  REGUP  RRS  ECRS
         rename = {
             "NSPIN": "Non-Spinning Reserves",
             "REGDN": "Regulation Down",
             "REGUP": "Regulation Up",
             "RRS": "Responsive Reserves",
+            "ECRS": "ERCOT Contingency Reserve Service",
         }
 
         col_order = [
@@ -1005,7 +1008,11 @@ class Ercot(ISOBase):
             "Regulation Down",
             "Regulation Up",
             "Responsive Reserves",
+            "ERCOT Contingency Reserve Service",
         ]
+
+        if "ECRS" not in doc.columns:
+            doc["ECRS"] = 0.0
 
         doc.rename(columns=rename, inplace=True)
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1012,7 +1012,7 @@ class Ercot(ISOBase):
         ]
 
         if "ECRS" not in doc.columns:
-            doc["ECRS"] = 0.0
+            doc["ECRS"] = None
 
         doc.rename(columns=rename, inplace=True)
 

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -19,6 +19,7 @@ class TestErcot(BaseTestISO):
             "Regulation Down",
             "Regulation Up",
             "Responsive Reserves",
+            "ERCOT Contingency Reserve Service",
         ]
 
         # today


### PR DESCRIPTION
add new ERCOT AS ECRS product support and testing (#233)

```python
>>> import gridstatus
>>> iso = gridstatus.Ercot()
>>> iso.get_as_prices(date="6/10/2023")

                        Time            Interval Start  ... Responsive Reserves ERCOT Contingency Reserve Service
0  2023-06-10 00:00:00-05:00 2023-06-10 00:00:00-05:00  ...                2.05                             10.00
1  2023-06-10 01:00:00-05:00 2023-06-10 01:00:00-05:00  ...                1.69                              7.01
2  2023-06-10 02:00:00-05:00 2023-06-10 02:00:00-05:00  ...                1.69                             10.00
3  2023-06-10 03:00:00-05:00 2023-06-10 03:00:00-05:00  ...                1.45                             10.00
4  2023-06-10 04:00:00-05:00 2023-06-10 04:00:00-05:00  ...                2.05                              7.01
5  2023-06-10 05:00:00-05:00 2023-06-10 05:00:00-05:00  ...                3.06                             10.00
6  2023-06-10 06:00:00-05:00 2023-06-10 06:00:00-05:00  ...                3.50                             10.91
7  2023-06-10 07:00:00-05:00 2023-06-10 07:00:00-05:00  ...                3.95                             15.88
8  2023-06-10 08:00:00-05:00 2023-06-10 08:00:00-05:00  ...                3.41                             30.98
9  2023-06-10 09:00:00-05:00 2023-06-10 09:00:00-05:00  ...                5.95                             40.00
10 2023-06-10 10:00:00-05:00 2023-06-10 10:00:00-05:00  ...                5.19                             31.24
11 2023-06-10 11:00:00-05:00 2023-06-10 11:00:00-05:00  ...                5.00                             31.49
12 2023-06-10 12:00:00-05:00 2023-06-10 12:00:00-05:00  ...                6.91                             41.91
13 2023-06-10 13:00:00-05:00 2023-06-10 13:00:00-05:00  ...               10.25                             55.25
14 2023-06-10 14:00:00-05:00 2023-06-10 14:00:00-05:00  ...                9.56                             45.48
15 2023-06-10 15:00:00-05:00 2023-06-10 15:00:00-05:00  ...               20.75                             59.40
16 2023-06-10 16:00:00-05:00 2023-06-10 16:00:00-05:00  ...               16.67                             60.70
17 2023-06-10 17:00:00-05:00 2023-06-10 17:00:00-05:00  ...               14.60                             49.94
18 2023-06-10 18:00:00-05:00 2023-06-10 18:00:00-05:00  ...               11.47                             57.47
19 2023-06-10 19:00:00-05:00 2023-06-10 19:00:00-05:00  ...               18.20                             57.68
20 2023-06-10 20:00:00-05:00 2023-06-10 20:00:00-05:00  ...               13.15                             58.15
21 2023-06-10 21:00:00-05:00 2023-06-10 21:00:00-05:00  ...                5.48                             30.91
22 2023-06-10 22:00:00-05:00 2023-06-10 22:00:00-05:00  ...                5.61                             11.08
23 2023-06-10 23:00:00-05:00 2023-06-10 23:00:00-05:00  ...                4.25                             10.00

[24 rows x 9 columns]
```