### PR TITLE
Add Ercot Hourly Resource Outage Capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Zone Name                      Time            Interval Start              Inter
 - Add `Ercot.get_unplanned_resource_outages()`
 - Add `Ercot.get_highest_price_as_offer_selected()`
 - Add `Ercot.get_as_reports()`
+- Add `Ercot.get_hourly_resource_outage_capacity()`
 
 #### `ERCOT.get_load_by_weather_zone`
 

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -505,6 +505,64 @@ class TestErcot(BaseTestISO):
 
         assert df.columns.tolist() == cols
 
+    def test_get_hourly_resource_outage_capacity(self):
+        cols = [
+            "Publish Time",
+            "Time",
+            "Interval Start",
+            "Interval End",
+            "Total Resource MW Zone South",
+            "Total Resource MW Zone North",
+            "Total Resource MW Zone West",
+            "Total Resource MW Zone Houston",
+            "Total Resource MW",
+            "Total IRR MW Zone South",
+            "Total IRR MW Zone North",
+            "Total IRR MW Zone West",
+            "Total IRR MW Zone Houston",
+            "Total IRR MW",
+            "Total New Equip Resource MW Zone South",
+            "Total New Equip Resource MW Zone North",
+            "Total New Equip Resource MW Zone West",
+            "Total New Equip Resource MW Zone Houston",
+            "Total New Equip Resource MW",
+        ]
+
+        # test specific hour
+        date = pd.Timestamp.now(tz=self.iso.default_timezone) - pd.Timedelta(
+            days=1,
+        )
+        df = self.iso.get_hourly_resource_outage_capacity(date)
+
+        assert df.shape[0] >= 0
+        assert df.columns.tolist() == cols
+
+        # test latest and confirm published in last 2 hours
+        df = self.iso.get_hourly_resource_outage_capacity("latest")
+        assert df.shape[0] >= 0
+        assert df.columns.tolist() == cols
+
+        assert df["Publish Time"].min() >= pd.Timestamp.now(
+            tz=self.iso.default_timezone,
+        ) - pd.Timedelta(hours=2)
+
+        # test date range
+        end = date.floor("H")
+        start = end - pd.Timedelta(
+            hours=3,
+        )
+        df = self.iso.get_hourly_resource_outage_capacity(
+            start=start,
+            end=end,
+            verbose=True,
+        )
+
+        assert df.shape[0] >= 0
+        assert df.columns.tolist() == cols
+        assert df["Publish Time"].nunique() == 3
+
+        return df
+
     """get_storage"""
 
     def test_get_storage_historical(self):


### PR DESCRIPTION
```python
>>> import gridstatus
>>> iso = gridstatus.Ercot()
>>> iso.get_hourly_resource_outage_capacity("latest")
                 Publish Time                      Time            Interval Start              Interval End  ...  Total New Equip Resource MW Zone North  Total New Equip Resource MW Zone West  Total New Equip Resource MW Zone Houston  Total New Equip Resource MW
0   2023-07-01 12:02:49-05:00 2023-06-30 23:00:00-05:00 2023-06-30 23:00:00-05:00 2023-07-01 00:00:00-05:00  ...                                    1936                                    938                                       101                         3971
1   2023-07-01 12:02:49-05:00 2023-07-01 00:00:00-05:00 2023-07-01 00:00:00-05:00 2023-07-01 01:00:00-05:00  ...                                    1936                                    938                                       101                         3971
2   2023-07-01 12:02:49-05:00 2023-07-01 01:00:00-05:00 2023-07-01 01:00:00-05:00 2023-07-01 02:00:00-05:00  ...                                    1936                                    938                                       101                         3971
3   2023-07-01 12:02:49-05:00 2023-07-01 02:00:00-05:00 2023-07-01 02:00:00-05:00 2023-07-01 03:00:00-05:00  ...                                    1936                                    938                                       101                         3971
4   2023-07-01 12:02:49-05:00 2023-07-01 03:00:00-05:00 2023-07-01 03:00:00-05:00 2023-07-01 04:00:00-05:00  ...                                    1936                                    938                                       101                         3971
..                        ...                       ...                       ...                       ...  ...                                     ...                                    ...                                       ...                          ...
187 2023-07-01 12:02:49-05:00 2023-07-08 18:00:00-05:00 2023-07-08 18:00:00-05:00 2023-07-08 19:00:00-05:00  ...                                    1936                                    828                                       101                         3851
188 2023-07-01 12:02:49-05:00 2023-07-08 19:00:00-05:00 2023-07-08 19:00:00-05:00 2023-07-08 20:00:00-05:00  ...                                    1936                                    828                                       101                         3851
189 2023-07-01 12:02:49-05:00 2023-07-08 20:00:00-05:00 2023-07-08 20:00:00-05:00 2023-07-08 21:00:00-05:00  ...                                    1936                                    828                                       101                         3851
190 2023-07-01 12:02:49-05:00 2023-07-08 21:00:00-05:00 2023-07-08 21:00:00-05:00 2023-07-08 22:00:00-05:00  ...                                    1936                                    828                                       101                         3851
191 2023-07-01 12:02:49-05:00 2023-07-08 22:00:00-05:00 2023-07-08 22:00:00-05:00 2023-07-08 23:00:00-05:00  ...                                    1936                                    828                                       101                         3851

[192 rows x 19 columns]
```