### PR TITLE
NYISO optimize when start and end date are same day

### DIFF
--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -718,6 +718,11 @@ class NYISO(ISOBase):
         month = date.strftime("%Y%m01")
         day = date.strftime("%Y%m%d")
 
+        # if same day, we can just download the single file
+        if end is not None and date.normalize() == end.normalize():
+            end = None
+            date = date.normalize()
+
         # the last 7 days of file are hosted directly as csv
         # todo this can probably be optimized to down single csv if
         # a range and all files are in the last 7 days

--- a/gridstatus/tests/test_nyiso.py
+++ b/gridstatus/tests/test_nyiso.py
@@ -316,9 +316,6 @@ class TestNYISO(BaseTestISO):
 
         assert df.columns.tolist() == columns
         assert df.shape[0] >= 0
-        import pdb
-
-        pdb.set_trace()
 
         # test range last month
         start = "2023-04-30"


### PR DESCRIPTION
This situation

```python
    iso = NYISO()

    iso.get_lmp(
        date=(
            pd.Timestamp("2023-07-03 06:25:00+0000", tz="UTC"),
            pd.Timestamp("2023-07-03 14:30:40.152411+0000", tz="UTC"),
        ),
        market="REAL_TIME_5_MIN",
    )

```