### PR TITLE
Fix Failing SPP Tests

### DIFF
--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -86,6 +86,9 @@ class SPP(ISOBase):
         LOCATION_TYPE_SETTLEMENT_LOCATION,
     ]
 
+    def __init__(self, verify_ssl=True):
+        self.verify_ssl = verify_ssl
+
     def get_status(self, date=None, verbose=False):
         if date != "latest":
             raise NotSupported()
@@ -482,7 +485,12 @@ class SPP(ISOBase):
             "returnGeometry": "false",
             "outFields": "*",
         }
-        doc = self._get_json(base_url, params=args, verbose=verbose)
+        doc = self._get_json(
+            base_url,
+            params=args,
+            verbose=verbose,
+            verify=self.verify_ssl,
+        )
         df = pd.DataFrame([feature["attributes"] for feature in doc["features"]])
         return df
 

--- a/gridstatus/tests/test_spp.py
+++ b/gridstatus/tests/test_spp.py
@@ -11,7 +11,9 @@ from gridstatus.tests.decorators import with_markets
 
 
 class TestSPP(BaseTestISO):
-    iso = SPP()
+    # dont verify to make tests pass
+    # on github actions
+    iso = SPP(verify_ssl=False)
 
     """get_fuel_mix"""
 


### PR DESCRIPTION
Attempting fix the SPP lmp tests that are failing on github actions with an SSL error, but run without problem in other enviornments

here is an action where they are failing: https://github.com/kmax12/gridstatus/actions/runs/5892948248/job/15983385496?pr=263

except from logs

```_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = Retry(total=0, connect=None, read=False, redirect=None, status=None)
method = 'GET'
url = '/arcgis/rest/services/MarketMaps/RTBM_FeatureData/MapServer/1/query?f=json&where=OBJECTID+IS+NOT+NULL&returnGeometry=false&outFields=%2A'
response = None
error = SSLError(SSLError(1, '[SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:1007)'))
_pool = <urllib3.connectionpool.HTTPSConnectionPool object at 0x7f703a8c9e70>
_stacktrace = <traceback object at 0x7f7039955fc0>

    def increment(
        self,
        method: str | None = None,
        url: str | None = None,
        response: BaseHTTPResponse | None = None,
        error: Exception | None = None,
        _pool: ConnectionPool | None = None,
        _stacktrace: TracebackType | None = None,
    ) -> Retry:
        """Return a new Retry object with incremented retry counters.
    
        :param response: A response object, or None, if the server did not
            return a response.
        :type response: :class:`~urllib3.response.BaseHTTPResponse`
        :param Exception error: An error encountered during the request, or
            None if the response was received successfully.
    
        :return: A new ``Retry`` object.
        """
        if self.total is False and error:
            # Disabled, indicate to re-raise the error.
            raise reraise(type(error), error, _stacktrace)
    
        total = self.total
        if total is not None:
            total -= 1
    
        connect = self.connect
        read = self.read
        redirect = self.redirect
        status_count = self.status
        other = self.other
        cause = "unknown"
        status = None
        redirect_location = None
    
        if error and self._is_connection_error(error):
            # Connect retry?
            if connect is False:
                raise reraise(type(error), error, _stacktrace)
            elif connect is not None:
  /home/runner/work/gridstatus/gridstatus/gridstatus/nyiso.py:448: UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.
    queue["Proposed Initial-Sync Date"] = pd.to_datetime(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED gridstatus/tests/test_spp.py::TestSPP::test_get_status_latest - Runtim...
FAILED gridstatus/tests/test_spp.py::TestSPP::test_lmp_date_range[Markets.DAY_AHEAD_HOURLY]
FAILED gridstatus/tests/test_spp.py::TestSPP::test_get_lmp_historical[Markets.DAY_AHEAD_HOURLY]
FAILED gridstatus/tests/test_spp.py::TestSPP::test_get_lmp_latest_with_locations[Markets.REAL_TIME_5_MIN-Interface]
FAILED gridstatus/tests/test_spp.py::TestSPP::test_get_lmp_latest_settlement_type_returns_three_location_types
FAILED gridstatus/tests/test_spp.py::TestSPP::test_get_lmp_historical[Markets.REAL_TIME_5_MIN]
FAILED gridstatus/tests/test_spp.py::TestSPP::test_get_lmp_today[Markets.DAY_AHEAD_HOURLY]
FAILED gridstatus/tests/test_spp.py::TestSPP::test_get_lmp_today[Markets.REAL_TIME_5_MIN]
FAILED gridstatus/tests/test_spp.py::TestSPP::test_get_lmp_latest[Markets.REAL_TIME_5_MIN]
FAILED gridstatus/tests/test_spp.py::TestSPP::test_get_lmp_latest_with_locations[Markets.REAL_TIME_5_MIN-Hub]
```