### PR TITLE
Use pyarrow-backed DataFrame with read_csv

### DIFF
--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -529,7 +529,7 @@ class CAISO(ISOBase):
         msg = f"Downloading interconnection queue from {url}"
         log(msg, verbose)
 
-        sheets = pd.read_excel(url, skiprows=3, sheet_name=None)
+        sheets = pd.read_excel(url, skiprows=3, sheet_name=None, dtype_backend="pyarrow")
 
         # remove legend at the bottom
         queued_projects = sheets["Grid GenerationQueue"][:-8]
@@ -882,7 +882,7 @@ class CAISO(ISOBase):
         )
 
         log(f"Fetching {url}", verbose=verbose)
-        df = pd.read_excel(url, usecols="B:M")
+        df = pd.read_excel(url, usecols="B:M", dtype_backend="pyarrow")
 
         # the outage mrid row is not the first row and it changes
         # so find it and make it the column names, then drop the rows
@@ -1152,7 +1152,7 @@ def _get_historical(file, date, verbose=False):
             msg = f"Fetching URL: {url}"
             log(msg, verbose)
 
-    df = pd.read_csv(url)
+    df = pd.read_csv(url, dtype_backend="pyarrow")
 
     # sometimes there are extra rows at the end, so this lets us ignore them
     df = df.dropna(subset=["Time"])
@@ -1215,7 +1215,7 @@ def _get_oasis(config, start, end=None, raw_data=False, verbose=False, sleep=5):
     # parse and concat all files
     dfs = []
     for f in z.namelist():
-        df = pd.read_csv(z.open(f))
+        df = pd.read_csv(z.open(f), dtype_backend="pyarrow")
         dfs.append(df)
 
     df = pd.concat(dfs)

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -1180,7 +1180,7 @@ def _get_historical(file, date, verbose=False):
             msg = f"Fetching URL: {url}"
             log(msg, verbose)
 
-    df = pd.read_csv(url, dtype_backend="pyarrow")
+    df = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
 
     # sometimes there are extra rows at the end, so this lets us ignore them
     df = df.dropna(subset=["Time"])
@@ -1243,7 +1243,7 @@ def _get_oasis(config, start, end=None, raw_data=False, verbose=False, sleep=5):
     # parse and concat all files
     dfs = []
     for f in z.namelist():
-        df = pd.read_csv(z.open(f), dtype_backend="pyarrow")
+        df = pd.read_csv(z.open(f), engine="pyarrow", dtype_backend="pyarrow")
         dfs.append(df)
 
     df = pd.concat(dfs)

--- a/gridstatus/eia.py
+++ b/gridstatus/eia.py
@@ -204,7 +204,8 @@ class EIA:
         def fetch_grid_monitor(grid_monitor):
             url = grid_monitor["URL"]
             log(f"Fetching data from {url}", verbose=verbose)
-            df = pd.read_excel(url, sheet_name="Published Hourly Data")
+            df = pd.read_excel(url, sheet_name="Published Hourly Data",
+                               dtype_backend="pyarrow")
 
             rename = {
                 "NG": "Net Generation",

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1155,9 +1155,9 @@ class Ercot(ISOBase):
         assert gen_resource_file, "Could not find gen resource file"
         assert smne_file, "Could not find smne file"
 
-        load_resource = pd.read_csv(z.open(load_resource_file), dtype_backend="pyarrow")
-        gen_resource = pd.read_csv(z.open(gen_resource_file), dtype_backend="pyarrow")
-        smne = pd.read_csv(z.open(smne_file), dtype_backend="pyarrow")
+        load_resource = pd.read_csv(z.open(load_resource_file), engine="pyarrow", dtype_backend="pyarrow")
+        gen_resource = pd.read_csv(z.open(gen_resource_file), engine="pyarrow", dtype_backend="pyarrow")
+        smne = pd.read_csv(z.open(smne_file), engine="pyarrow", dtype_backend="pyarrow")
 
         def handle_time(df, time_col, is_interval_end=False):
             df[time_col] = pd.to_datetime(df[time_col])
@@ -1275,7 +1275,7 @@ class Ercot(ISOBase):
         data = {}
 
         for key, file in files.items():
-            doc = pd.read_csv(z.open(file), dtype_backend="pyarrow")
+            doc = pd.read_csv(z.open(file), engine="pyarrow", dtype_backend="pyarrow")
             # weird that these files dont have this column like all other eroct files
             # add so we can parse
             doc["DSTFlag"] = "N"
@@ -1741,7 +1741,7 @@ class Ercot(ISOBase):
             if as_name in ["ECRSM", "ECRSS"] and cleared not in z.namelist():
                 continue
 
-            df_cleared = pd.read_csv(z.open(cleared), dtype_backend="pyarrow")
+            df_cleared = pd.read_csv(z.open(cleared), engine="pyarrow", dtype_backend="pyarrow")
             all_dfs.append(df_cleared)
 
         for as_name in self_arranged_products:
@@ -1751,7 +1751,7 @@ class Ercot(ISOBase):
             if as_name in ["ECRSM", "ECRSS"] and self_arranged not in z.namelist():
                 continue
 
-            df_self_arranged = pd.read_csv(z.open(self_arranged), dtype_backend="pyarrow")
+            df_self_arranged = pd.read_csv(z.open(self_arranged), engine="pyarrow", dtype_backend="pyarrow")
             all_dfs.append(df_self_arranged)
 
         def _make_bid_curve(df):
@@ -1767,7 +1767,7 @@ class Ercot(ISOBase):
             if as_name in ["ECRSM", "ECRSS"] and offers not in z.namelist():
                 continue
 
-            df_offers = pd.read_csv(z.open(offers), dtype_backend="pyarrow")
+            df_offers = pd.read_csv(z.open(offers), engine="pyarrow", dtype_backend="pyarrow")
             name = f"Bid Curve - {as_name}"
             if df_offers.empty:
                 # use last df to get the index
@@ -1833,7 +1833,7 @@ class Ercot(ISOBase):
         log("Reading SCED System Lambda files", verbose)
 
         df = pd.concat(
-            [pd.read_csv(i.url, compression="zip") for i in tqdm.tqdm(docs)],
+            [pd.read_csv(i.url, engine="pyarrow", dtype_backend="pyarrow", compression="zip") for i in tqdm.tqdm(docs)],
         )
 
         df["SCED Time Stamp"] = pd.to_datetime(df["SCEDTimeStamp"]).dt.tz_localize(
@@ -2116,12 +2116,12 @@ class Ercot(ISOBase):
         settlement_points_file = [
             name for name in names if "Settlement_Points" in name
         ][0]
-        df = pd.read_csv(z.open(settlement_points_file), dtype_backend="pyarrow")
+        df = pd.read_csv(z.open(settlement_points_file),engine="pyarrow", dtype_backend="pyarrow")
         return df
 
     def read_doc(self, doc, verbose=False):
         log(f"Reading {doc.url}", verbose)
-        df = pd.read_csv(doc.url, compression="zip")
+        df = pd.read_csv(doc.url, engine="pyarrow", compression="zip", dtype_backend="pyarrow")
         return self.parse_doc(df, verbose=verbose)
 
     def parse_doc(self, doc, verbose=False):

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -324,7 +324,7 @@ class ISONE(ISOBase):
                         u,
                         skiprows=[0, 1, 2, 3, 5],
                         skipfooter=1,
-                        engine="python",
+                        engine="pyarrow",
                         dtype_backend="pyarrow",
                     ),
                 )
@@ -688,7 +688,7 @@ def _make_request(url, skiprows, verbose):
         io.StringIO(response.content.decode("utf8")),
         skiprows=skiprows,
         skipfooter=1,
-        engine="python",
+        engine="pyarrow",
         dtype_backend="pyarrow",
     ).drop_duplicates()
     return df

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -325,6 +325,7 @@ class ISONE(ISOBase):
                         skiprows=[0, 1, 2, 3, 5],
                         skipfooter=1,
                         engine="python",
+                        dtype_backend="pyarrow",
                     ),
                 )
 
@@ -521,7 +522,7 @@ class ISONE(ISOBase):
         log(msg, verbose)
 
         r = requests.get("https://irtt.iso-ne.com/reports/external")
-        queue = pd.read_html(r.text, attrs={"id": "publicqueue"})[0]
+        queue = pd.read_html(r.text, attrs={"id": "publicqueue"}, dtype_backend="pyarrow")[0]
 
         # only keep generator interconnection requests
         queue["Type"] = queue["Type"].map(
@@ -688,6 +689,7 @@ def _make_request(url, skiprows, verbose):
         skiprows=skiprows,
         skipfooter=1,
         engine="python",
+        dtype_backend="pyarrow",
     ).drop_duplicates()
     return df
 

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -186,7 +186,7 @@ class MISO(ISOBase):
                 url = today_url
 
             log(f"Downloading LMP data from {url}", verbose)
-            data = pd.read_csv(url, dtype_backend="pyarrow")
+            data = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
 
             data["Interval Start"] = (
                 pd.to_datetime(data["INTERVAL"])
@@ -200,7 +200,7 @@ class MISO(ISOBase):
             today = utils._handle_date("today", self.default_timezone)
             url = f"https://docs.misoenergy.org/marketreports/{today.strftime('%Y%m%d')}_da_expost_lmp.csv"  # noqa
             log(f"Downloading LMP data from {url}", verbose)
-            today_dam_data = pd.read_csv(url, skiprows=4, dtype_backend="pyarrow")
+            today_dam_data = pd.read_csv(url, skiprows=4, engine="pyarrow", dtype_backend="pyarrow")
             node_to_type = today_dam_data[["Node", "Type"]].drop_duplicates()
             data = data.merge(
                 node_to_type,
@@ -214,7 +214,7 @@ class MISO(ISOBase):
         elif market == Markets.DAY_AHEAD_HOURLY:
             url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_da_expost_lmp.csv"  # noqa
             log(f"Downloading LMP data from {url}", verbose)
-            raw_data = pd.read_csv(url, skiprows=4, dtype_backend="pyarrow")
+            raw_data = pd.read_csv(url, skiprows=4, engine="pyarrow", dtype_backend="pyarrow")
             data_melted = raw_data.melt(
                 id_vars=["Node", "Type", "Value"],
                 value_vars=[col for col in raw_data.columns if col.startswith("HE")],

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -186,7 +186,7 @@ class MISO(ISOBase):
                 url = today_url
 
             log(f"Downloading LMP data from {url}", verbose)
-            data = pd.read_csv(url)
+            data = pd.read_csv(url, dtype_backend="pyarrow")
 
             data["Interval Start"] = (
                 pd.to_datetime(data["INTERVAL"])
@@ -200,7 +200,7 @@ class MISO(ISOBase):
             today = utils._handle_date("today", self.default_timezone)
             url = f"https://docs.misoenergy.org/marketreports/{today.strftime('%Y%m%d')}_da_expost_lmp.csv"  # noqa
             log(f"Downloading LMP data from {url}", verbose)
-            today_dam_data = pd.read_csv(url, skiprows=4)
+            today_dam_data = pd.read_csv(url, skiprows=4, dtype_backend="pyarrow")
             node_to_type = today_dam_data[["Node", "Type"]].drop_duplicates()
             data = data.merge(
                 node_to_type,
@@ -214,7 +214,7 @@ class MISO(ISOBase):
         elif market == Markets.DAY_AHEAD_HOURLY:
             url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_da_expost_lmp.csv"  # noqa
             log(f"Downloading LMP data from {url}", verbose)
-            raw_data = pd.read_csv(url, skiprows=4)
+            raw_data = pd.read_csv(url, skiprows=4, dtype_backend="pyarrow")
             data_melted = raw_data.melt(
                 id_vars=["Node", "Type", "Value"],
                 value_vars=[col for col in raw_data.columns if col.startswith("HE")],

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -344,6 +344,7 @@ class NYISO(ISOBase):
         all_sheets = pd.read_excel(
             url,
             sheet_name=["Interconnection Queue", "Withdrawn"],
+            dtype_backend="pyarrow"
         )
 
         # Drop extra rows at bottom
@@ -365,7 +366,8 @@ class NYISO(ISOBase):
         withdrawn = withdrawn.rename(columns={"Utility ": "Utility"})
 
         # make completed look like the other two sheets
-        completed = pd.read_excel(url, sheet_name="In Service", header=[0, 1])
+        completed = pd.read_excel(url, sheet_name="In Service", header=[0, 1],
+                                  dtype_backend="pyarrow")
         completed.insert(15, "SGIA Tender Date", None)
         completed.insert(16, "CY Complete Date", None)
         completed.insert(17, "Proposed Initial-Sync Date", None)
@@ -529,7 +531,7 @@ class NYISO(ISOBase):
         msg = f"Requesting {url}"
         log(msg, verbose)
 
-        df = pd.read_csv(url)
+        df = pd.read_csv(url, dtype_backend="pyarrow")
 
         # need to be updated once a year. approximately around end of april
         # find it here: https://www.nyiso.com/gold-book-resources
@@ -546,6 +548,7 @@ class NYISO(ISOBase):
             ],
             skiprows=3,
             header=[0, 1, 2, 3, 4],
+            dtype_backend="pyarrow",
         )
 
         generators["Table III-2a"]["Generator Type"] = "Market Generator"
@@ -662,7 +665,7 @@ class NYISO(ISOBase):
         msg = f"Requesting {url}"
         log(msg, verbose)
 
-        df = pd.read_csv(url)
+        df = pd.read_csv(url, dtype_backend="pyarrow")
 
         return df
 
@@ -734,7 +737,7 @@ class NYISO(ISOBase):
             msg = f"Requesting {csv_url}"
             log(msg, verbose)
 
-            df = pd.read_csv(csv_url)
+            df = pd.read_csv(csv_url, dtype_backend="pyarrow")
             df = _handle_time(df, dataset_name)
             df["File Date"] = date.normalize()
         else:
@@ -769,7 +772,7 @@ class NYISO(ISOBase):
                     msg = f"{csv_filename} not found in {zip_url}"
                     log(msg, verbose)
                     continue
-                df = pd.read_csv(z.open(csv_filename))
+                df = pd.read_csv(z.open(csv_filename), dtype_backend="pyarrow")
                 df["File Date"] = d.normalize()
 
                 df = _handle_time(df, dataset_name)
@@ -833,7 +836,7 @@ class NYISO(ISOBase):
         msg = f"Requesting {url}"
         log(msg, verbose)
 
-        df = pd.read_excel(url, sheet_name="MCP Table", header=[0, 1])
+        df = pd.read_excel(url, sheet_name="MCP Table", header=[0, 1], dtype_backend="pyarrow")
 
         df.rename(columns={"Unnamed: 0_level_0": "", "Date": ""}, inplace=True)
         df.set_index("", inplace=True)

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -531,7 +531,7 @@ class NYISO(ISOBase):
         msg = f"Requesting {url}"
         log(msg, verbose)
 
-        df = pd.read_csv(url, dtype_backend="pyarrow")
+        df = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
 
         # need to be updated once a year. approximately around end of april
         # find it here: https://www.nyiso.com/gold-book-resources
@@ -665,7 +665,7 @@ class NYISO(ISOBase):
         msg = f"Requesting {url}"
         log(msg, verbose)
 
-        df = pd.read_csv(url, dtype_backend="pyarrow")
+        df = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
 
         return df
 
@@ -737,7 +737,7 @@ class NYISO(ISOBase):
             msg = f"Requesting {csv_url}"
             log(msg, verbose)
 
-            df = pd.read_csv(csv_url, dtype_backend="pyarrow")
+            df = pd.read_csv(csv_url, engine="pyarrow", dtype_backend="pyarrow")
             df = _handle_time(df, dataset_name)
             df["File Date"] = date.normalize()
         else:
@@ -772,7 +772,7 @@ class NYISO(ISOBase):
                     msg = f"{csv_filename} not found in {zip_url}"
                     log(msg, verbose)
                     continue
-                df = pd.read_csv(z.open(csv_filename), dtype_backend="pyarrow")
+                df = pd.read_csv(z.open(csv_filename), engine="pyarrow", dtype_backend="pyarrow")
                 df["File Date"] = d.normalize()
 
                 df = _handle_time(df, dataset_name)

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -600,7 +600,7 @@ class PJM(ISOBase):
                 "Referer": "https://www.pjm.com/",
             },
         )
-        queue = pd.read_excel(io.BytesIO(r.content))
+        queue = pd.read_excel(io.BytesIO(r.content), dtype_backend="pyarrow")
 
         queue["Capacity (MW)"] = queue[["MFO", "MW In Service"]].min(axis=1)
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -121,7 +121,7 @@ class SPP(ISOBase):
             raise NotSupported
 
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/generation-mix-historical?path=/GenMix2Hour.csv"  # noqa
-        df_raw = pd.read_csv(url, dtype_backend="pyarrow")
+        df_raw = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
         historical_mix = process_gen_mix(df_raw, detailed=detailed)
 
         historical_mix = historical_mix.drop(
@@ -286,7 +286,7 @@ class SPP(ISOBase):
         msg = f"Downloading {url}"
         log(msg, verbose)
 
-        df = pd.read_csv(url)
+        df = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
 
         return self._process_capacity_of_generation_on_outage(df, publish_time=date)
 
@@ -366,7 +366,7 @@ class SPP(ISOBase):
 
         msg = f"Downloading {url}"
         log(msg, verbose)
-        df = pd.read_csv(url, dtype_backend="pyarrow")
+        df = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
 
         return self._process_ver_curtailments(df)
 
@@ -440,7 +440,7 @@ class SPP(ISOBase):
         msg = f"Getting interconnection queue from {url}"
         log(msg, verbose)
 
-        queue = pd.read_csv(url, skiprows=1, dtype_backend="pyarrow")
+        queue = pd.read_csv(url, skiprows=1, engine="pyarrow", dtype_backend="pyarrow")
 
         queue["Status (Original)"] = queue["Status"]
         completed_val = InterconnectionQueueStatus.COMPLETED.value
@@ -607,7 +607,7 @@ class SPP(ISOBase):
     ):
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/{FS_DAM_LMP_BY_LOCATION}?path=/{date.strftime('%Y')}/{date.strftime('%m')}/By_Day/DA-LMP-SL-{date.strftime('%Y%m%d')}0100.csv"  # noqa
         log(f"Downloading {url}", verbose=verbose)
-        df = pd.read_csv(url, dtype_backend="pyarrow")
+        df = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
         return df
 
     def _finalize_spp_df(self, df, market, location_type, verbose=False):
@@ -698,7 +698,7 @@ class SPP(ISOBase):
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/lmp-by-settlement-location-weis?path=/{date.strftime('%Y')}/{date.strftime('%m')}/By_Day/WEIS-RTBM-LMP-DAILY-SL-{date.strftime('%Y%m%d')}.csv"  # noqa
         msg = f"Downloading {url}"
         log(msg, verbose)
-        df = pd.read_csv(url)
+        df = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
 
         return self._process_lmp_real_time_weis(df)
 
@@ -760,7 +760,7 @@ class SPP(ISOBase):
         for url in tqdm.tqdm(urls):
             msg = f"Fetching {url}"
             log(msg, verbose)
-            df = pd.read_csv(url, dtype_backend="pyarrow")
+            df = pd.read_csv(url, engine="pyarrow", dtype_backend="pyarrow")
             all_dfs.append(df)
         return pd.concat(all_dfs)
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -121,7 +121,7 @@ class SPP(ISOBase):
             raise NotSupported
 
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/generation-mix-historical?path=/GenMix2Hour.csv"  # noqa
-        df_raw = pd.read_csv(url)
+        df_raw = pd.read_csv(url, dtype_backend="pyarrow")
         historical_mix = process_gen_mix(df_raw, detailed=detailed)
 
         historical_mix = historical_mix.drop(
@@ -267,7 +267,7 @@ class SPP(ISOBase):
 
         msg = f"Downloading {url}"
         log(msg, verbose)
-        df = pd.read_csv(url)
+        df = pd.read_csv(url, dtype_backend="pyarrow")
 
         return self._process_ver_curtailments(df)
 
@@ -291,7 +291,7 @@ class SPP(ISOBase):
         all_dfs = []
         for f in z.filelist:
             if f.filename.endswith(".csv"):
-                df = pd.read_csv(z.open(f.filename))
+                df = pd.read_csv(z.open(f.filename), dtype_backend="pyarrow")
                 all_dfs.append(df)
 
         df = pd.concat(all_dfs)
@@ -352,7 +352,7 @@ class SPP(ISOBase):
         msg = f"Getting interconnection queue from {url}"
         log(msg, verbose)
 
-        queue = pd.read_csv(url, skiprows=1)
+        queue = pd.read_csv(url, skiprows=1, dtype_backend="pyarrow")
 
         queue["Status (Original)"] = queue["Status"]
         completed_val = InterconnectionQueueStatus.COMPLETED.value
@@ -519,7 +519,7 @@ class SPP(ISOBase):
     ):
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/{FS_DAM_LMP_BY_LOCATION}?path=/{date.strftime('%Y')}/{date.strftime('%m')}/By_Day/DA-LMP-SL-{date.strftime('%Y%m%d')}0100.csv"  # noqa
         log(f"Downloading {url}", verbose=verbose)
-        df = pd.read_csv(url)
+        df = pd.read_csv(url, dtype_backend="pyarrow")
         return df
 
     def _finalize_spp_df(self, df, market, location_type, verbose=False):
@@ -613,7 +613,7 @@ class SPP(ISOBase):
         for url in tqdm.tqdm(urls):
             msg = f"Fetching {url}"
             log(msg, verbose)
-            df = pd.read_csv(url)
+            df = pd.read_csv(url, dtype_backend="pyarrow")
             all_dfs.append(df)
         return pd.concat(all_dfs)
 

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -260,7 +260,7 @@ def load_folder(path, time_zone=None, verbose=True):
 
     dfs = []
     for f in tqdm.tqdm(all_files, disable=not verbose):
-        df = pd.read_csv(f, parse_dates=True)
+        df = pd.read_csv(f, parse_dates=True, dtype_backend="pyarrow")
         dfs.append(df)
 
     data = pd.concat(dfs).reset_index(drop=True)

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -211,7 +211,7 @@ def download_csvs_from_zip_url(url, process_csv=None, verbose=False):
     all_dfs = []
     for f in z.filelist:
         if f.filename.endswith(".csv"):
-            df = pd.read_csv(z.open(f.filename))
+            df = pd.read_csv(z.open(f.filename), engine="pyarrow", dtype_backend="pyarrow")
             if process_csv:
                 df = process_csv(df, f.filename)
             all_dfs.append(df)
@@ -276,7 +276,7 @@ def load_folder(path, time_zone=None, verbose=True):
 
     dfs = []
     for f in tqdm.tqdm(all_files, disable=not verbose):
-        df = pd.read_csv(f, parse_dates=True, dtype_backend="pyarrow")
+        df = pd.read_csv(f, parse_dates=True, engine="pyarrow", dtype_backend="pyarrow")
         dfs.append(df)
 
     data = pd.concat(dfs).reset_index(drop=True)


### PR DESCRIPTION
- Use PyArrow backed data types for at reading data since PyArrow can be significantly faster and more memory-efficient than NumPy
- Starting with pandas 3.0 will change the default for string strings to PyArrow (such as when calling read_csv). 
  - [Source](https://twitter.com/pandas_dev/status/1697608898960675261) 
- Example:
  - <img width="611" alt="Screenshot 2023-10-10 at 7 35 58 PM" src="https://github.com/kmax12/gridstatus/assets/8726321/362a6b11-2b84-4e05-afb7-4b32b05c0cd9">

