### PR TITLE
Require PJM API Key

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,9 @@
 # Register at https://www.eia.gov/opendata/register.php for an API key
 EIA_API_KEY=
 
+# Register at https://apiportal.pjm.com/ for an API key
+PJM_API_KEY=
+
 # Register at https://apiexplorer.ercot.com/ for username/password
 # and follow instructions at
 # https://developer.ercot.com/applications/pubapi/ERCOT%20Public%20API%20Registration%20and%20Authentication/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,8 +11,6 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
     env:
-      # This is not a secret because it is a free API key. At worst,
-      # we may hit the rate limit.
       EIA_API_KEY: ${{ secrets.EIA_API_KEY }}
       PJM_API_KEY: ${{ secrets.PJM_API_KEY }}
       ERCOT_API_USERNAME: ${{ secrets.ERCOT_API_USERNAME }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,11 @@ jobs:
     env:
       # This is not a secret because it is a free API key. At worst,
       # we may hit the rate limit.
-      EIA_API_KEY: "9e1a7ae3ce839e9ad174eb4028b7a7b2"
+      EIA_API_KEY: ${{ secrets.EIA_API_KEY }}
+      PJM_API_KEY: ${{ secrets.PJM_API_KEY }}
+      ERCOT_API_USERNAME: ${{ secrets.ERCOT_API_USERNAME }}
+      ERCOT_API_PASSWORD: ${{ secrets.ERCOT_API_PASSWORD }}
+      ERCOT_API_SUBSCRIPTION_KEY: ${{ secrets.ERCOT_API_SUBSCRIPTION_KEY }}
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.28.0 - Mar 20, 2024
+
+### Breaking Changes
+
+* PJM requires an `api_key` on initialization (can be set as `PJM_API_KEY` environment variable)
+
 ## v0.27.0 - Mar 4, 2024
 
 ### Breaking Changes

--- a/Makefile
+++ b/Makefile
@@ -7,23 +7,19 @@ clean:
 	find . -name '.coverage.*' -delete
 
 PYTEST_CMD := poetry run pytest -s -vv gridstatus/ -n auto --reruns 5 --reruns-delay 3
-NOT_SLOW_AND_NOT_REQUIRES_ERCOT_AUTH := -m "not slow and not requires_ercot_auth"
+NOT_SLOW := -m "not slow"
 
 .PHONY: test
 test:
-	$(PYTEST_CMD) $(NOT_SLOW_AND_NOT_REQUIRES_ERCOT_AUTH)
+	$(PYTEST_CMD) $(NOT_SLOW)
 
 .PHONY: test-cov
 test-cov:
-	$(PYTEST_CMD) $(NOT_SLOW_AND_NOT_REQUIRES_ERCOT_AUTH) --cov=gridstatus --cov-config=./pyproject.toml --cov-report=xml:./coverage.xml
-
-.PHONY: test-ercot-api
-test-ercot-api:
-	$(PYTEST_CMD) -m "not slow and requires_ercot_auth"
+	$(PYTEST_CMD) $(NOT_SLOW) --cov=gridstatus --cov-config=./pyproject.toml --cov-report=xml:./coverage.xml
 
 .PHONY: test-slow
 test-slow:
-	$(PYTEST_CMD) -m "slow and not requires_ercot_auth"
+	$(PYTEST_CMD) -m "slow"
 
 .PHONY: installdeps-dev
 installdeps-dev:

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -1150,12 +1150,3 @@ class PJM(ISOBase):
         ]
 
         return df.sort_values("Interval Start").reset_index(drop=True)
-
-    def _get_key(self):
-        # Not using retries here, should we be?
-        settings = self._get_json(
-            "https://dataminer2.pjm.com/config/settings.json",
-            verbose=False,
-        )
-
-        return settings["subscriptionKey"]

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -427,9 +427,10 @@ class PJM(ISOBase):
                 at https://www.pjm.com/
         """
         super().__init__()
-        self._api_key = api_key or os.getenv("PJM_API_KEY")
+        self.retries = retries
+        self.api_key = api_key or os.getenv("PJM_API_KEY")
 
-        if not self._api_key:
+        if not self.api_key:
             raise ValueError("api_key must be provided or set in PJM_API_KEY env var")
 
     @support_date_range(frequency="365D")

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -1,12 +1,11 @@
 import math
+import os
 import warnings
 from typing import BinaryIO
 
 import pandas as pd
 import requests
 import tqdm
-
-import os
 
 from gridstatus import utils
 from gridstatus.base import ISOBase, Markets, NoDataFoundException, NotSupported

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -899,7 +899,12 @@ class PJM(ISOBase):
                 start.strftime("%m/%d/%Y %H:%M") + "to" + end.strftime("%m/%d/%Y %H:%M")
             )
 
-        msg = f"Retrieving data from {endpoint} with params {final_params}"
+        # Exclude API key from logs
+        params_to_log = final_params.copy()
+        if "Ocp-Apim-Subscription-Key" in params_to_log:
+            params_to_log["Ocp-Apim-Subscription-Key"] = "API_KEY_HIDDEN"
+
+        msg = f"Retrieving data from {endpoint} with params {params_to_log}"
         log(msg, verbose)
 
         r = self._get_json(

--- a/gridstatus/tests/test_ercot_api.py
+++ b/gridstatus/tests/test_ercot_api.py
@@ -11,7 +11,6 @@ from gridstatus.ercot_api.ercot_api import HISTORICAL_DAYS_THRESHOLD, ErcotAPI
 from gridstatus.tests.base_test_iso import TestHelperMixin
 
 
-@pytest.mark.requires_ercot_auth
 class TestErcotAPI(TestHelperMixin):
     @classmethod
     def setup_class(cls):

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -1,3 +1,6 @@
+import os
+from unittest import mock
+
 import pandas as pd
 import pytest
 
@@ -11,6 +14,25 @@ from gridstatus.tests.decorators import with_markets
 
 class TestPJM(BaseTestISO):
     iso = PJM()
+
+    @mock.patch.dict(os.environ, {"PJM_API_KEY": "test_env"})
+    def test_api_key_from_env(self):
+        # test that api key is set from env var
+        no_api_key = PJM()
+        assert no_api_key._api_key is None
+        assert no_api_key._get_api_key() == "test_env"
+
+    def test_api_key_from_arg(self):
+        # test that api key is set from arg
+        api_key = PJM(api_key="test")
+        assert api_key._get_api_key() == "test"
+
+    @mock.patch.dict(os.environ, {"PJM_API_KEY": ""})
+    def test_api_key_raises_if_missing(self):
+        # test that no api key raises
+        iso = PJM(api_key=None)
+        with pytest.raises(ValueError):
+            iso._get_api_key()
 
     """get_fuel_mix"""
 

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -18,21 +18,18 @@ class TestPJM(BaseTestISO):
     @mock.patch.dict(os.environ, {"PJM_API_KEY": "test_env"})
     def test_api_key_from_env(self):
         # test that api key is set from env var
-        no_api_key = PJM()
-        assert no_api_key._api_key is None
-        assert no_api_key._get_api_key() == "test_env"
+        pjm = PJM()
+        assert pjm.api_key == "test_env"
 
     def test_api_key_from_arg(self):
         # test that api key is set from arg
-        api_key = PJM(api_key="test")
-        assert api_key._get_api_key() == "test"
+        pjm = PJM(api_key="test")
+        assert pjm.api_key == "test"
 
     @mock.patch.dict(os.environ, {"PJM_API_KEY": ""})
     def test_api_key_raises_if_missing(self):
-        # test that no api key raises
-        iso = PJM(api_key=None)
         with pytest.raises(ValueError):
-            iso._get_api_key()
+            _ = PJM(api_key=None)
 
     """get_fuel_mix"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,6 @@ build-backend = "poetry.core.masonry.api"
 testpaths = ["gridstatus/tests/*"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    # TODO: figure out how to run tests in PRs that require
-    # ERCOT authentication
-    "requires_ercot_auth: requires ERCOT authentication via environment variables (deselect with '-m \"not requires_ercot_auth\"')",
 ]
 
 [tool.black]


### PR DESCRIPTION
Require providing API key during initialization or using `PJM_API_KEY` environment variables. Register for an API key at https://www.pjm.com/.