### PR TITLE
Raw interconnection queue data

### DIFF
--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import BinaryIO
 
 import requests
 
@@ -93,7 +94,10 @@ class ISOBase:
     def get_storage(self, date, end=None, verbose=False):
         raise NotImplementedError()
 
-    def get_interconnection_queue(self):
+    def get_raw_interconnection_queue(self, verbose: bool = False) -> BinaryIO:
+        raise NotImplementedError()
+
+    def get_interconnection_queue(self, verbose: bool = False):
         raise NotImplementedError()
 
     def _latest_lmp_from_today(self, market, locations, **kwargs):

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -533,6 +533,8 @@ class CAISO(ISOBase):
         response = requests.get(url)
         if response.status_code == 200:
             return io.BytesIO(response.content)
+        else:
+            raise RuntimeError(f"GET {url} failed: {response}")
 
     def get_interconnection_queue(self, verbose=False):
         raw_data = self.get_raw_interconnection_queue(verbose)
@@ -1243,7 +1245,11 @@ def _get_oasis(config, start, end=None, raw_data=False, verbose=False, sleep=5):
         time.sleep(sleep)
 
     # this is when no data is available
-    if ".xml.zip;" in r.headers["Content-Disposition"] or b".xml" in r.content:
+    if (
+        "Content-Disposition" not in r.headers
+        or ".xml.zip;" in r.headers["Content-Disposition"]
+        or b".xml" in r.content
+    ):
         # avoid rate limiting
         time.sleep(sleep)
         return None

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -531,10 +531,9 @@ class CAISO(ISOBase):
         msg = f"Downloading interconnection queue from {url}"
         log(msg, verbose)
         response = requests.get(url)
-        if response.status_code == 200:
-            return io.BytesIO(response.content)
-        else:
+        if response.status_code != 200:
             raise RuntimeError(f"GET {url} failed: {response}")
+        return io.BytesIO(response.content)
 
     def get_interconnection_queue(self, verbose=False):
         raw_data = self.get_raw_interconnection_queue(verbose)

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -531,9 +531,7 @@ class CAISO(ISOBase):
         msg = f"Downloading interconnection queue from {url}"
         log(msg, verbose)
         response = requests.get(url)
-        if response.status_code != 200:
-            raise RuntimeError(f"GET {url} failed: {response}")
-        return io.BytesIO(response.content)
+        return utils.get_response_blob(response)
 
     def get_interconnection_queue(self, verbose=False):
         raw_data = self.get_raw_interconnection_queue(verbose)

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -738,9 +738,7 @@ class Ercot(ISOBase):
         msg = f"Downloading interconnection queue from: {doc_info.url} "
         log(msg, verbose)
         response = requests.get(doc_info.url)
-        if response.status_code != 200:
-            raise RuntimeError(f"GET {doc_info.url} failed: {response}")
-        return io.BytesIO(response.content)
+        return utils.get_response_blob(response)
 
     def get_interconnection_queue(self, verbose=False):
         """

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -293,10 +293,9 @@ class MISO(ISOBase):
         log(msg, verbose)
 
         response = requests.get(url)
-        if response.status_code == 200:
-            return io.BytesIO(response.content)
-        else:
+        if response.status_code != 200:
             raise RuntimeError(f"GET {url} failed: {response}")
+        return io.BytesIO(response.content)
 
     def get_interconnection_queue(self, verbose=False):
         """Get the interconnection queue

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1,4 +1,3 @@
-import io
 import json
 from typing import BinaryIO
 
@@ -293,9 +292,7 @@ class MISO(ISOBase):
         log(msg, verbose)
 
         response = requests.get(url)
-        if response.status_code != 200:
-            raise RuntimeError(f"GET {url} failed: {response}")
-        return io.BytesIO(response.content)
+        return utils.get_response_blob(response)
 
     def get_interconnection_queue(self, verbose=False):
         """Get the interconnection queue

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -416,7 +416,7 @@ class NYISO(ISOBase):
         )
 
         # the spreadsheet doesnt have a date, so make it null
-        completed["Proposed  In-Service"] = None
+        completed["Proposed In-Service"] = None
         completed["Proposed COD"] = None
         # assume it was finished when last updated
         completed["Actual Completion Date"] = completed["Last Updated Date"]
@@ -477,8 +477,8 @@ class NYISO(ISOBase):
             queue["Proposed COD"],
             errors="coerce",
         )
-        queue["Proposed  In-Service"] = pd.to_datetime(
-            queue["Proposed  In-Service"],
+        queue["Proposed In-Service"] = pd.to_datetime(
+            queue["Proposed In-Service"],
             errors="coerce",
         )
         queue["Proposed Initial-Sync Date"] = pd.to_datetime(
@@ -508,7 +508,7 @@ class NYISO(ISOBase):
         }
 
         extra_columns = [
-            "Proposed  In-Service",
+            "Proposed In-Service",
             "Proposed Initial-Sync Date",
             "Last Updated Date",
             "Z",

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -385,7 +385,35 @@ class NYISO(ISOBase):
             and "SGIA Tender Date" not in completed.columns
         ):
             active = active.drop(columns=["SGIA Tender Date"])
-        completed.columns = active.columns
+        completed_colnames_map = {
+            ("Queue", "Pos."): "Queue Pos.",
+            ("Queue", "Owner/Developer"): "Developer Name",
+            ("Queue", "Project Name"): "Project Name",
+            ("Date", "of IR"): "Date of IR",
+            ("SP", "(MW)"): "SP (MW)",
+            ("WP", "(MW)"): "WP (MW)",
+            ("Type/", "Fuel"): "Type/ Fuel",
+            ("Location", "County"): "County",
+            ("Location", "State"): "State",
+            ("Z", "Unnamed: 9_level_1"): "Z",
+            ("Interconnection", "Point"): "Points of Interconnection",
+            ("Interconnection", "Utility "): "Utility",
+            ("Interconnection", "S"): "S",
+            ("Last Update", "Unnamed: 13_level_1"): "Last Updated Date",
+            ("Availability", "of Studies"): "Availability of Studies",
+            ("SGIA Tender Date", ""): "SGIA Tender Date",
+            ("CY Complete Date", ""): "CY Complete Date",
+            ("Proposed Initial-Sync Date", ""): "Proposed Initial-Sync Date",
+            ("Proposed", " In-Service"): "Proposed In-Service Date",
+            ("Proposed", "COD"): "Proposed COD",
+            ("Proposed", "COD.1"): "Proposed COD.1",
+            ("Proposed", "COD.2"): "Proposed COD.2",
+            ("Proposed", "COD.3"): "Proposed COD.3",
+            ("Status", ""): "Status",
+        }
+        completed.columns = completed.columns.to_flat_index().map(
+            lambda c: completed_colnames_map[c],
+        )
 
         # the spreadsheet doesnt have a date, so make it null
         completed["Proposed  In-Service"] = None

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -397,7 +397,7 @@ class NYISO(ISOBase):
             ("Location", "County"): "County",
             ("Location", "State"): "State",
             ("Z", "Unnamed: 9_level_1"): "Z",
-            ("Interconnection", "Point"): "Points of Interconnection",
+            ("Interconnection", "Point"): "Interconnection Point",
             ("Interconnection", "Utility "): "Utility",
             ("Interconnection", "S"): "S",
             ("Last Update", "Unnamed: 13_level_1"): "Last Updated Date",

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1,4 +1,3 @@
-import io
 from typing import BinaryIO
 
 import pandas as pd
@@ -334,9 +333,7 @@ class NYISO(ISOBase):
         msg = f"Downloading interconnection queue from {url}"
         log(msg, verbose)
         response = requests.get(url)
-        if response.status_code != 200:
-            raise RuntimeError(f"GET {url} failed: {response}")
-        return io.BytesIO(response.content)
+        return utils.get_response_blob(response)
 
     def get_interconnection_queue(self, verbose=False):
         """Return NYISO interconnection queue

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -415,9 +415,6 @@ class NYISO(ISOBase):
             lambda c: completed_colnames_map[c],
         )
 
-        # the spreadsheet doesnt have a date, so make it null
-        completed["Proposed In-Service"] = None
-        completed["Proposed COD"] = None
         # assume it was finished when last updated
         completed["Actual Completion Date"] = completed["Last Updated Date"]
 
@@ -477,8 +474,8 @@ class NYISO(ISOBase):
             queue["Proposed COD"],
             errors="coerce",
         )
-        queue["Proposed In-Service"] = pd.to_datetime(
-            queue["Proposed In-Service"],
+        queue["Proposed In-Service Date"] = pd.to_datetime(
+            queue["Proposed In-Service Date"],
             errors="coerce",
         )
         queue["Proposed Initial-Sync Date"] = pd.to_datetime(
@@ -508,7 +505,7 @@ class NYISO(ISOBase):
         }
 
         extra_columns = [
-            "Proposed In-Service",
+            "Proposed In-Service Date",
             "Proposed Initial-Sync Date",
             "Last Updated Date",
             "Z",

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -65,7 +65,8 @@ class NYISO(ISOBase):
                 row["Notes"] = [row["Status"]]
 
                 row["Status"] = row["Status"][
-                    row["Status"].index(STATE_CHANGE) + len(STATE_CHANGE) : -len(
+                    row["Status"].index(STATE_CHANGE)
+                    + len(STATE_CHANGE) : -len(
                         " state.**",
                     )
                 ].capitalize()

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -1,4 +1,3 @@
-import io
 import math
 import warnings
 from typing import BinaryIO
@@ -969,9 +968,7 @@ class PJM(ISOBase):
                 "Referer": "https://www.pjm.com/",
             },
         )
-        if response.status_code != 200:
-            raise RuntimeError(f"GET {url} failed: {response}")
-        return io.BytesIO(response.content)
+        return utils.get_response_blob(response)
 
     def get_interconnection_queue(self, verbose=False):
         raw_data = self.get_raw_interconnection_queue(verbose)

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -684,7 +684,8 @@ class SPP(ISOBase):
         # todo where does date got in argument order
         # def get_historical_lmp(self, date, market: str, nodes: list):
         # 5 minute interal data
-        # {FILE_BROWSER_API_URL}/rtbm-lmp-by-location?path=/2022/08/By_Interval/08/RTBM-LMP-SL-202208082125.csv
+        # {FILE_BROWSER_API_URL}/rtbm-lmp-by-location?path=/2022/08/By_Interval/08
+        # /RTBM-LMP-SL-202208082125.csv
 
         # historical generation mix
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -1,4 +1,3 @@
-import io
 from typing import BinaryIO
 
 import pandas as pd
@@ -698,9 +697,7 @@ class SPP(ISOBase):
         msg = f"Getting interconnection queue from {url}"
         log(msg, verbose)
         response = requests.get(url)
-        if response.status_code != 200:
-            raise RuntimeError(f"GET {url} failed: {response}")
-        return io.BytesIO(response.content)
+        return utils.get_response_blob(response)
 
     def get_interconnection_queue(self, verbose=False):
         """Get interconnection queue

--- a/gridstatus/tests/test_interconnection_queue.py
+++ b/gridstatus/tests/test_interconnection_queue.py
@@ -9,4 +9,5 @@ import gridstatus
 def test_get_interconnection_queue_all(iso_class):
     """Get interconnection queue data for all ISOs"""
     iso = iso_class()
-    iso.get_interconnection_queue()
+    queue = iso.get_interconnection_queue()
+    assert not queue.empty

--- a/gridstatus/tests/test_interconnection_queue.py
+++ b/gridstatus/tests/test_interconnection_queue.py
@@ -5,6 +5,8 @@ import gridstatus
 
 # todo implement this
 @pytest.mark.slow
-def test_get_interconnection_queue_all():
+@pytest.mark.parametrize("iso_class", gridstatus.utils.all_isos)
+def test_get_interconnection_queue_all(iso_class):
     """Get interconnection queue data for all ISOs"""
-    gridstatus.get_interconnection_queues()
+    iso = iso_class()
+    iso.get_interconnection_queue()

--- a/gridstatus/tests/test_interconnection_queue.py
+++ b/gridstatus/tests/test_interconnection_queue.py
@@ -2,10 +2,27 @@ import pytest
 
 import gridstatus
 
+interconnection_queues = [
+    pytest.param(iso_class)
+    for iso_class in gridstatus.utils.all_isos
+    if iso_class != gridstatus.IESO
+] + [
+    pytest.param(
+        gridstatus.IESO,
+        marks=pytest.mark.xfail(
+            reason="IESO has no interconnection queue implementation yet",
+            strict=True,
+        ),
+    ),
+]
+
 
 # todo implement this
 @pytest.mark.slow
-@pytest.mark.parametrize("iso_class", gridstatus.utils.all_isos)
+@pytest.mark.parametrize(
+    "iso_class",
+    interconnection_queues,
+)
 def test_get_interconnection_queue_all(iso_class):
     """Get interconnection queue data for all ISOs"""
     iso = iso_class()

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -206,6 +206,12 @@ def get_zip_folder(url, verbose=False):
     return z
 
 
+def get_response_blob(resp: requests.Response) -> io.BytesIO:
+    if resp.status_code != 200:
+        raise RuntimeError(f"{resp.request.method} {resp.request.url} failed: {resp}")
+    return io.BytesIO(resp.content)
+
+
 def download_csvs_from_zip_url(url, process_csv=None, verbose=False):
     z = get_zip_folder(url, verbose=verbose)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ test = [
     "pytest-cov == 4.0.0",
 ]
 dev = [
-    "ruff == 0.0.202",
+    "ruff >= 0.0.291",
     "black[jupyter] == 22.12.0",
     "pre-commit == 2.21.0",
 ]


### PR DESCRIPTION
Closes #305.

This adds a `get_raw_interconnection_queue` method to all `ISOBase` subclasses that outputs a `BinaryIO`. This allows users like Catalyst to archive the raw data, including data that we don't know how to interpret within GridStatus yet.

I parametrized the `test_interconnection_queue` test so that a failure in one ISO doesn't fail the whole thing. This helps us isolate test failures. I also added an assertion that the queue data is non-empty to slightly strengthen the tests, and fixed the NYISO column mapping code to handle a change in their data format.