### PR TITLE
Fix formatting in GridStatus class: Add newline after reserves

### DIFF
--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -134,7 +134,7 @@ class GridStatus:
             s += "Status Homepage: %s \n" % self.iso.status_homepage
 
         if self.reserves is not None:
-            s += "Reserves: %.0f %s" % (self.reserves, self.unit)
+            s += "Reserves: %.0f %s \n" % (self.reserves, self.unit)
 
         if self.notes and len(self.notes):
             s += "Notes:\n"


### PR DESCRIPTION
Added '\n' to self.reserves to fix output of:
`gridstatus.ercot.Ercot().get_status("latest")`

###Output###
Electric Reliability Council of Texas
Time: 2024-01-14 12:14:20-06:00 
Status: Normal 
Status Homepage: https://www.ercot.com/gridmktinfo/dashboards/gridconditions 
Reserves: 8819 **MWNotes:**
-  There is enough power for current demand.

###Expected Output###
Electric Reliability Council of Texas
Time: 2024-01-14 12:14:20-06:00 
Status: Normal 
Status Homepage: https://www.ercot.com/gridmktinfo/dashboards/gridconditions 
Reserves: 8819 MW
Notes:
-  There is enough power for current demand.