### PR TITLE
EIA_API_KEY as Repo Varariable and Remove Python 3.8, 3.9 from Test Matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Print environment variables
+        run: |
+          echo "EIA_API_KEY: $EIA_API_KEY"
       - name: Install dependencies
         run: |
           python -m pip install ".[test]"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
     env:
-      EIA_API_KEY: "test"
+      # This is not a secret because it is a free API key. At worst,
+      # we may hit the rate limit.
+      EIA_API_KEY: "9e1a7ae3ce839e9ad174eb4028b7a7b2"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     env:
-      EIA_API_KEY: ${{ secrets.EIA_API_KEY }}
+      EIA_API_KEY: ${{ vars.EIA_API_KEY }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     env:
       EIA_API_KEY: ${{ vars.EIA_API_KEY }}
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,8 @@ jobs:
       - name: Print environment variables
         run: |
           echo "EIA_API_KEY: $EIA_API_KEY"
+        env:
+          EIA_API_KEY: ${{ vars.EIA_API_KEY }}
       - name: Install dependencies
         run: |
           python -m pip install ".[test]"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
     env:
-      EIA_API_KEY: ${{ vars.EIA_API_KEY }}
+      EIA_API_KEY: "test"
     steps:
       - uses: actions/checkout@v3
 
@@ -22,8 +22,6 @@ jobs:
       - name: Print environment variables
         run: |
           echo "EIA_API_KEY: $EIA_API_KEY"
-        env:
-          EIA_API_KEY: ${{ vars.EIA_API_KEY }}
       - name: Install dependencies
         run: |
           python -m pip install ".[test]"


### PR DESCRIPTION
- Use a repo variable for `EIA_API_KEY`. See: https://github.com/kmax12/gridstatus/issues/310
- Removes Python 3.8 and 3.9 from the test matrix