### PR TITLE
SPP Solar and Wind Short and Mid Term Forecasts and Load Short and Mid Term Forecasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### SPP
 
 - Add support for operating reserves
+- Add `spp.get_solar_and_wind_forecast_short_term` and `spp.get_solar_and_wind_forecast_mid_term` for solar and wind forecasts
+- Add `spp.get_load_forecast_short_term` and `spp.get_load_forecast_long_term` for load forecasts
+  - This overlaps with the existing `spp.get_load_forecast` method, which we want to eventually remove in favor of these two methods.
 
 ## v0.24.0 - Dec 27, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 ### SPP
 
-- Add support for operating reserves
 - Add `spp.get_solar_and_wind_forecast_short_term` and `spp.get_solar_and_wind_forecast_mid_term` for solar and wind forecasts
 - Add `spp.get_load_forecast_short_term` and `spp.get_load_forecast_long_term` for load forecasts
   - This overlaps with the existing `spp.get_load_forecast` method, which we want to eventually remove in favor of these two methods.
+- Add support for operating reserves
+
+### ERCOT
+
+- Added initial support for using the ERCOT API
 
 ## v0.24.0 - Dec 27, 2023
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -22,6 +22,10 @@ BASE_SOLAR_AND_WIND_MID_TERM_URL = (
     f"{FILE_BROWSER_DOWNLOAD_URL}/midterm-resource-forecast?path="
 )
 
+BASE_LOAD_FORECAST_SHORT_TERM_URL = f"{FILE_BROWSER_DOWNLOAD_URL}/stlf-vs-actual?path="
+
+BASE_LOAD_FORECAST_MID_TERM_URL = f"{FILE_BROWSER_DOWNLOAD_URL}/mtlf-vs-actual?path="
+
 
 LOCATION_TYPE_ALL = "ALL"
 LOCATION_TYPE_HUB = "Hub"
@@ -206,10 +210,126 @@ class SPP(ISOBase):
         return current_day_forecast
 
     @support_date_range("5_MIN")
+    def get_load_forecast_short_term(self, date, end=None, verbose=False):
+        """
+        5-minute load forecast data for the SPP footprint (system-wide) for +/- 10
+        minutes. Also includes actual load.
+
+        Data from https://portal.spp.org/pages/stlf-vs-actual
+
+        Arguments:
+            date (pd.Timestamp|str): date to get data for. Supports "latest" and "today"
+            verbose (bool): print info
+
+        Returns:
+            pd.DataFrame: forecast as dataframe.
+        """
+        # The short_term forecast is delayed up to 2 minutes.
+        buffer_minutes = 2
+
+        if date == "latest":
+            date = self.now() - pd.Timedelta(minutes=buffer_minutes)
+
+        # Files do not exist in the future
+        if date > self.now():
+            return
+
+        url = self._short_term_load_forecast_url(date.floor("5T"))
+
+        log(f"Downloading {url}", verbose=verbose)
+        df = pd.read_csv(url)
+
+        # According to the docs, the end time col should be GMTIntervalEnd, but it's
+        # only GMTInterval in the data
+        df = self._post_process_load_forecast(
+            df,
+            url,
+            forecast_type="SHORT_TERM",
+            forecast_col="STLF",
+            end_time_col="GMTInterval",
+            interval_duration=pd.Timedelta(minutes=5),
+        )
+
+        return df
+
+    @support_date_range("HOUR_START")
+    def get_load_forecast_mid_term(self, date, end=None, verbose=False):
+        """
+        Returns load forecast for +7 days in hourly intervals. Includes actual load
+        for the past 24 hours. Data from https://portal.spp.org/pages/mtlf-vs-actual
+
+        Arguments:
+            date (pd.Timestamp|str): date to get data for. Supports "latest" and "today"
+            verbose (bool): print info
+
+        Returns:
+            pd.DataFrame: forecast as dataframe.
+        """
+        # The MID_TERM forecast is delayed up to 10 minutes.
+        buffer_minutes = 10
+
+        if date == "latest":
+            date = self.now() - pd.Timedelta(minutes=buffer_minutes)
+
+        if date > self.now():
+            return
+
+        url = self._mid_term_load_forecast_url(date.floor("H"))
+
+        log(f"Downloading {url}", verbose=verbose)
+        df = pd.read_csv(url)
+
+        df = self._post_process_load_forecast(
+            df,
+            url,
+            forecast_type="MID_TERM",
+            forecast_col="MTLF",
+            end_time_col="GMTIntervalEnd",
+            interval_duration=pd.Timedelta(hours=1),
+        )
+
+        return df
+
+    def _post_process_load_forecast(
+        self,
+        df,
+        url,
+        forecast_type,
+        forecast_col,
+        end_time_col,
+        interval_duration,
+    ):
+        df = self._handle_market_end_to_interval(df, end_time_col, interval_duration)
+
+        # Assume the publish time is in the name of the file. There are different
+        # times on the webpage, but these could be the posting time.
+        df["Publish Time"] = pd.Timestamp(
+            url.split("-")[-1].split(".")[0],
+            tz=self.default_timezone,
+        )
+
+        df.columns = [col.strip() for col in df.columns]
+
+        df["Forecast Type"] = forecast_type
+
+        df = (
+            utils.move_cols_to_front(
+                df,
+                ["Interval Start", "Interval End", "Publish Time", "Forecast Type"],
+            )
+            .drop(columns=["Time", "Interval"])
+            .sort_values(["Interval Start", "Publish Time"])
+        )
+
+        return df.dropna(subset=[forecast_col]).reset_index(drop=True)
+
+    @support_date_range("5_MIN")
     def get_solar_and_wind_forecast_short_term(self, date, end=None, verbose=False):
         """
         Returns solar and wind generation forecast for +4 hours in 5 minute intervals.
         Include actuals for past day in 5 minute intervals.
+
+        Data from https://portal.spp.org/pages/shortterm-resource-forecast
 
         Arguments:
             date (pd.Timestamp|str): date to get data for. Supports "latest" and "today"
@@ -249,6 +369,8 @@ class SPP(ISOBase):
     def get_solar_and_wind_forecast_mid_term(self, date, end=None, verbose=False):
         """
         Returns solar and wind generation forecast for +7 days in hourly intervals.
+
+        Data from https://portal.spp.org/pages/midterm-resource-forecast.
 
         Arguments:
             date (pd.Timestamp|str): date to get data for. Supports "latest" and "today"
@@ -330,6 +452,23 @@ class SPP(ISOBase):
         # Explicitly set the minutes to 00.
         return BASE_SOLAR_AND_WIND_MID_TERM_URL + date.strftime(
             "/%Y/%m/%d/OP-MTRF-%Y%m%d%H00.csv",
+        )
+
+    def _short_term_load_forecast_url(self, date):
+        hour = date.hour
+        padded_hour = str(hour).zfill(2)
+        padded_hour_plus_one = str((hour + 1) % 24).zfill(2)
+
+        # The first hour in the URL is 1 after the hour in the filename.
+        # Example 2024/01/01/02 has data for 01/01/2024 01:00:00 - 01/01/2024 01:55:00
+        return BASE_LOAD_FORECAST_SHORT_TERM_URL + date.strftime(
+            f"/%Y/%m/%d/{padded_hour_plus_one}/OP-STLF-%Y%m%d{padded_hour}%M.csv",
+        )
+
+    def _mid_term_load_forecast_url(self, date):
+        # Explicitly set the minutes to 00.
+        return BASE_LOAD_FORECAST_MID_TERM_URL + date.strftime(
+            "/%Y/%m/%d/OP-MTLF-%Y%m%d%H00.csv",
         )
 
     def _handle_market_end_to_interval(self, df, column, interval_duration):

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -300,7 +300,9 @@ class SPP(ISOBase):
             .sort_values(["Interval Start", "Publish Time"])
         )
 
-        return df.dropna(subset=["Wind Forecast MW", "Solar Forecast MW"])
+        return df.dropna(subset=["Wind Forecast MW", "Solar Forecast MW"]).reset_index(
+            drop=True,
+        )
 
     def _short_term_solar_and_wind_url(self, date):
         hour = date.hour

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -241,9 +241,13 @@ class SPP(ISOBase):
                 verbose=verbose,
             )
 
+        df.columns = [col.strip() for col in df.columns]
+
         # Don't include the actuals to avoid confusion
         cols_to_drop = [col for col in df if "Actual" in col]
-        df = df.drop(columns=cols_to_drop)
+        df = df.drop(columns=cols_to_drop).dropna(
+            subset=["Wind Forecast MW", "Solar Forecast MW"],
+        )
 
         if end:
             return df[df["Interval Start"].between(date, end)]
@@ -272,10 +276,10 @@ class SPP(ISOBase):
             verbose=verbose,
         )
 
+        df.columns = [col.strip() for col in df.columns]
+
         # Don't include the forecast to avoid confusion
         cols_to_drop = [col for col in df if "Forecast" in col]
-
-        df.columns = [col.strip() for col in df.columns]
 
         df = df.drop(columns=cols_to_drop).dropna(
             subset=["Actual Wind MW", "Actual Solar MW"],

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -222,11 +222,11 @@ class SPP(ISOBase):
 
         now = self.now() - pd.Timedelta(minutes=buffer_minutes)
 
-        if date in ["latest", "today"]:
+        if date == "latest":
             date = now
 
-        date = utils._handle_date(date, self.default_timezone)
-        date = min(now, date)
+        # date = utils._handle_date(date, self.default_timezone)
+        # date = min(now, date)
 
         if end:
             end = utils._handle_date(end, self.default_timezone)
@@ -285,11 +285,11 @@ class SPP(ISOBase):
 
         now = self.now() - pd.Timedelta(minutes=buffer_minutes)
 
-        if date in ["latest", "today"]:
-            date = now
+        # if date in ["latest", "today"]:
+        #     date = now
 
-        date = utils._handle_date(date, self.default_timezone)
-        date = min(now, date)
+        # date = utils._handle_date(date, self.default_timezone)
+        # date = min(now, date)
 
         if end:
             end = utils._handle_date(end, self.default_timezone)

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -201,42 +201,50 @@ class SPP(ISOBase):
 
         return current_day_forecast
 
-    def get_solar_and_wind_forecast(
-        self,
-        date,
-        forecast_type="MID_TERM",
-        verbose=False,
-    ):
-        """Returns solar and wind generation forecast either for +4 hours in
-        5 minute intervals or +7 days in hourly intervals. +4 hour forecasts also
-        include actuals for past day in 5 minute intervals.
+    def get_solar_and_wind_forecast_short_term(self, date, verbose=False):
+        """
+        Returns solar and wind generation forecast for +4 hours in 5 minute intervals.
+        Include actuals for past day in 5 minute intervals.
 
         Arguments:
             date (pd.Timestamp|str): date to get data for. Supports "latest" and "today"
-            forecast_type (str): MID_TERM is hourly for next 7 days or SHORT_TERM is
-                every five minutes for 4 hours.
             verbose (bool): print info
 
         Returns:
             pd.DataFrame: forecast as dataframe.
         """
-        # The MID_TERM forecast is delayed up to 10 minutes. The SHORT_TERM forecast
-        # is delayed up to 2 minutes.
-        buffer_minutes = 10 if forecast_type == "MID_TERM" else 2
+        # The SHORT_TERM forecast is delayed up to 2 minutes.
+        buffer_minutes = 2
 
         if date in ["latest", "today"]:
             date = pd.Timestamp.now(tz=self.default_timezone) - pd.Timedelta(
                 minutes=buffer_minutes,
             )
 
-        if forecast_type == "MID_TERM":
-            return self._get_solar_and_wind_forecast_hourly(date, verbose=verbose)
-        elif forecast_type == "SHORT_TERM":
-            return self._get_solar_and_wind_forecast_5_min(date, verbose=verbose)
-        else:
-            raise RuntimeError("Invalid forecast type")
+        return self._get_solar_and_wind_forecast_short_term(date, verbose=verbose)
 
-    def _get_solar_and_wind_forecast_hourly(self, date, verbose=False):
+    def get_solar_and_wind_forecast_mid_term(self, date, verbose=False):
+        """
+        Returns solar and wind generation forecast for +7 days in hourly intervals.
+
+        Arguments:
+            date (pd.Timestamp|str): date to get data for. Supports "latest" and "today"
+            verbose (bool): print info
+
+        Returns:
+            pd.DataFrame: forecast as dataframe.
+        """
+        # The MID_TERM forecast is delayed up to 10 minutes.
+        buffer_minutes = 10
+
+        if date in ["latest", "today"]:
+            date = pd.Timestamp.now(tz=self.default_timezone) - pd.Timedelta(
+                minutes=buffer_minutes,
+            )
+
+        return self._get_solar_and_wind_forecast_mid_term(date, verbose=verbose)
+
+    def _get_solar_and_wind_forecast_mid_term(self, date, verbose=False):
         """System-wide wind and solar forecast data for +7days by hour."""
         url = self._mid_term_solar_and_wind_url(date.floor("H"))
 
@@ -251,7 +259,7 @@ class SPP(ISOBase):
 
         return df
 
-    def _get_solar_and_wind_forecast_5_min(self, date, verbose=False):
+    def _get_solar_and_wind_forecast_short_term(self, date, verbose=False):
         """Solar and wind forecast for +4 hours by 5 minute interval."""
         url = self._short_term_solar_and_wind_url(date.floor("5T"))
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -237,6 +237,10 @@ class SPP(ISOBase):
         verbose=False,
     ):
         """Solar and wind forecast for +4 hours by 5 minute interval."""
+        # Files do not exist in the future
+        if date > self.now():
+            return
+
         url = self._short_term_solar_and_wind_url(date.floor("5T"))
 
         df = pd.read_csv(url)
@@ -277,6 +281,9 @@ class SPP(ISOBase):
     @support_date_range("HOUR_START")
     def _retrieve_solar_and_wind_forecast_mid_term(self, date, end=None, verbose=False):
         """System-wide wind and solar forecast data for +7days by hour."""
+        if date > self.now():
+            return
+
         url = self._mid_term_solar_and_wind_url(date.floor("H"))
 
         df = pd.read_csv(url)

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -220,8 +220,14 @@ class SPP(ISOBase):
         Returns:
             pd.DataFrame: forecast as dataframe.
         """
+        # The MID_TERM forecast is delayed up to 10 minutes. The SHORT_TERM forecast
+        # is delayed up to 2 minutes.
+        buffer_minutes = 10 if forecast_type == "MID_TERM" else 2
+
         if date in ["latest", "today"]:
-            date = pd.Timestamp.now(tz=self.default_timezone) - pd.Timedelta(minutes=10)
+            date = pd.Timestamp.now(tz=self.default_timezone) - pd.Timedelta(
+                minutes=buffer_minutes,
+            )
 
         if forecast_type == "MID_TERM":
             return self._get_solar_and_wind_forecast_hourly(date, verbose=verbose)
@@ -230,7 +236,6 @@ class SPP(ISOBase):
         else:
             raise RuntimeError("Invalid forecast type")
 
-    @support_date_range("HOUR_START")
     def _get_solar_and_wind_forecast_hourly(self, date, verbose=False):
         """System-wide wind and solar forecast data for +7days by hour."""
         url = self._mid_term_solar_and_wind_url(date.floor("H"))
@@ -246,7 +251,6 @@ class SPP(ISOBase):
 
         return df
 
-    @support_date_range("5_MIN")
     def _get_solar_and_wind_forecast_5_min(self, date, verbose=False):
         """Solar and wind forecast for +4 hours by 5 minute interval."""
         url = self._short_term_solar_and_wind_url(date.floor("5T"))

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -220,29 +220,12 @@ class SPP(ISOBase):
         # The short_term forecast is delayed up to 2 minutes.
         buffer_minutes = 2
 
-        now = self.now() - pd.Timedelta(minutes=buffer_minutes)
-
         if date == "latest":
-            date = now
+            date = self.now() - pd.Timedelta(minutes=buffer_minutes)
 
-        # date = utils._handle_date(date, self.default_timezone)
-        # date = min(now, date)
-
-        if end:
-            end = utils._handle_date(end, self.default_timezone)
-            # Make sure we don't request files that don't exist yet
-            end = min(now, end)
-
-        df = self._retrieve_solar_and_wind_forecast_short_term(
-            date,
-            end,
-            verbose,
-        )
+        df = self._retrieve_solar_and_wind_forecast_short_term(date, end, verbose)
 
         df["Forecast Type"] = "SHORT_TERM"
-
-        if end:
-            return df[df["Publish Time"].between(date, end)]
 
         return df
 
@@ -283,24 +266,11 @@ class SPP(ISOBase):
         # The MID_TERM forecast is delayed up to 10 minutes.
         buffer_minutes = 10
 
-        now = self.now() - pd.Timedelta(minutes=buffer_minutes)
-
-        # if date in ["latest", "today"]:
-        #     date = now
-
-        # date = utils._handle_date(date, self.default_timezone)
-        # date = min(now, date)
-
-        if end:
-            end = utils._handle_date(end, self.default_timezone)
-            # Make sure we don't request files that don't exist yet
-            end = min(now, end)
+        if date == "latest":
+            date = self.now() - pd.Timedelta(minutes=buffer_minutes)
 
         df = self._retrieve_solar_and_wind_forecast_mid_term(date, end, verbose)
         df["Forecast Type"] = "MID_TERM"
-
-        if end:
-            return df[df["Publish Time"].between(date, end)]
 
         return df
 

--- a/gridstatus/tests/test_spp.py
+++ b/gridstatus/tests/test_spp.py
@@ -345,7 +345,145 @@ class TestSPP(BaseTestISO):
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 
-    """get_solar_and_wind_forecast"""
+    """get_load_forecast_short_term"""
+
+    def test_get_load_forecast_short_term_today(self):
+        df = self.iso.get_load_forecast_short_term(date="today")
+
+        now = self.iso.now()
+
+        assert df["Publish Time"].min() == now.normalize()
+        assert df["Publish Time"].max() == (now).floor("5T")
+
+        assert df["Interval Start"].min() <= now
+        assert df["Interval Start"].max() >= now.floor("H")
+
+        self._check_load_forecast(df, "SHORT_TERM")
+
+    def test_get_load_forecast_short_term_latest(self):
+        latest = self.iso.get_load_forecast_short_term(date="latest")
+
+        # Single publish time
+        assert (
+            latest["Publish Time"]
+            == (self.iso.now() - pd.Timedelta(minutes=2)).floor("5T")
+        ).all()
+
+        self._check_load_forecast(latest, "SHORT_TERM")
+
+    def test_get_load_forecast_short_term_historical(self):
+        now = self.iso.now()
+
+        three_days_ago = now.normalize() - pd.Timedelta(days=3)
+
+        df = self.iso.get_load_forecast_short_term(date=three_days_ago)
+
+        assert (df["Publish Time"] == three_days_ago).all()
+
+        # Each file contains data going back into the past
+        assert df["Interval Start"].min() <= three_days_ago
+        assert df["Interval Start"].max() >= three_days_ago - pd.Timedelta(minutes=5)
+
+        self._check_load_forecast(df, "SHORT_TERM")
+
+    def test_get_load_forecast_short_term_hour_24_handling(self):
+        # This test checks we can successfully retrieve the 24th hour of the day
+        # which has a 00 ((23 + 1) % 24 = 0) for the hour in the file name.
+        two_days_ago_2300 = (
+            pd.Timestamp.now(tz=self.iso.default_timezone).normalize()
+            - pd.Timedelta(days=2)
+            + pd.Timedelta(hours=23, minutes=0)
+        )
+
+        one_day_ago_0000 = two_days_ago_2300 + pd.Timedelta(hours=1)
+
+        df = self.iso.get_load_forecast_short_term(
+            date=two_days_ago_2300,
+            end=one_day_ago_0000,
+        )
+
+        assert df["Publish Time"].min() == two_days_ago_2300
+        assert df["Publish Time"].max() == one_day_ago_0000 - pd.Timedelta(minutes=5)
+
+        self._check_load_forecast(df, "SHORT_TERM")
+
+    def test_get_load_forecast_short_term_historical_with_date_range(self):
+        now = self.iso.now()
+        three_days_ago = now.normalize() - pd.Timedelta(days=3)
+        three_days_ago_0345 = three_days_ago + pd.Timedelta(hours=3, minutes=45)
+
+        df = self.iso.get_load_forecast_short_term(
+            three_days_ago,
+            three_days_ago_0345,
+        )
+
+        assert df["Publish Time"].min() == three_days_ago
+        assert df["Publish Time"].max() == three_days_ago_0345 - pd.Timedelta(minutes=5)
+
+        self._check_load_forecast(df, "SHORT_TERM")
+
+    """get_load_forecast_mid_term"""
+
+    def test_get_load_forecast_mid_term_today(self):
+        df = self.iso.get_load_forecast_mid_term(date="today")
+
+        now = self.iso.now()
+
+        assert df["Publish Time"].min() == now.normalize()
+        assert df["Publish Time"].max() == (now).floor("H")
+
+        assert df["Interval Start"].min() <= now
+
+        time_in_future = pd.Timedelta(days=5)
+
+        assert df["Interval Start"].max() >= now + time_in_future
+
+        self._check_load_forecast(df, "MID_TERM")
+
+    def test_get_load_forecast_mid_term_latest(self):
+        latest = self.iso.get_load_forecast_mid_term(date="latest")
+
+        # Single publish time
+        assert (
+            latest["Publish Time"]
+            == (self.iso.now() - pd.Timedelta(minutes=10)).floor("H")
+        ).all()
+
+        self._check_load_forecast(latest, "MID_TERM")
+
+    def test_get_load_forecast_mid_term_historical(self):
+        now = self.iso.now()
+
+        three_days_ago = now.normalize() - pd.Timedelta(days=3)
+
+        df = self.iso.get_load_forecast_mid_term(date=three_days_ago)
+
+        assert (df["Publish Time"].unique() == three_days_ago).all()
+
+        # Each file contains data going back into the past
+        assert df["Interval Start"].min() <= three_days_ago
+        assert df["Interval Start"].max() >= three_days_ago + pd.Timedelta(days=6)
+
+        self._check_load_forecast(df, "MID_TERM")
+
+    def test_get_load_forecast_mid_term_historical_with_date_range(self):
+        now = self.iso.now()
+        three_days_ago = now.normalize() - pd.Timedelta(days=3)
+        three_days_ago_0345 = three_days_ago + pd.Timedelta(hours=3, minutes=45)
+
+        df = self.iso.get_load_forecast_mid_term(
+            three_days_ago,
+            three_days_ago_0345,
+        )
+
+        assert df["Publish Time"].min() == three_days_ago
+        assert df["Publish Time"].max() == three_days_ago_0345 - pd.Timedelta(
+            minutes=45,
+        )
+
+        self._check_load_forecast(df, "MID_TERM")
+
+    """get_solar_and_wind_forecast_short_term"""
 
     def test_get_solar_and_wind_forecast_short_term_today(self):
         df = self.iso.get_solar_and_wind_forecast_short_term(date="today")
@@ -373,33 +511,6 @@ class TestSPP(BaseTestISO):
         ).all()
 
         self._check_solar_and_wind_forecast(latest, "SHORT_TERM")
-
-    def test_get_solar_and_wind_forecast_mid_term_today(self):
-        df = self.iso.get_solar_and_wind_forecast_mid_term(date="today")
-
-        now = self.iso.now()
-
-        assert df["Publish Time"].min() == now.normalize()
-        assert df["Publish Time"].max() == (now).floor("H")
-
-        assert df["Interval Start"].min() <= now
-
-        time_in_future = pd.Timedelta(days=5)
-
-        assert df["Interval Start"].max() >= now + time_in_future
-
-        self._check_solar_and_wind_forecast(df, "MID_TERM")
-
-    def test_get_solar_and_wind_forecast_mid_term_latest(self):
-        latest = self.iso.get_solar_and_wind_forecast_mid_term(date="latest")
-
-        # Single publish time
-        assert (
-            latest["Publish Time"]
-            == (self.iso.now() - pd.Timedelta(minutes=10)).floor("H")
-        ).all()
-
-        self._check_solar_and_wind_forecast(latest, "MID_TERM")
 
     def test_get_solar_and_wind_forecast_short_term_historical(self):
         now = self.iso.now()
@@ -437,21 +548,6 @@ class TestSPP(BaseTestISO):
 
         self._check_solar_and_wind_forecast(df, "SHORT_TERM")
 
-    def test_get_solar_and_wind_forecast_mid_term_historical(self):
-        now = self.iso.now()
-
-        three_days_ago = now.normalize() - pd.Timedelta(days=3)
-
-        df = self.iso.get_solar_and_wind_forecast_mid_term(date=three_days_ago)
-
-        assert (df["Publish Time"].unique() == three_days_ago).all()
-
-        # Each file contains data going back into the past
-        assert df["Interval Start"].min() <= three_days_ago
-        assert df["Interval Start"].max() >= three_days_ago + pd.Timedelta(days=6)
-
-        self._check_solar_and_wind_forecast(df, "MID_TERM")
-
     def test_get_solar_and_wind_forecast_short_term_historical_with_date_range(self):
         now = self.iso.now()
         three_days_ago = now.normalize() - pd.Timedelta(days=3)
@@ -466,6 +562,50 @@ class TestSPP(BaseTestISO):
         assert df["Publish Time"].max() == three_days_ago_0345 - pd.Timedelta(minutes=5)
 
         self._check_solar_and_wind_forecast(df, "SHORT_TERM")
+
+    """get_solar_and_wind_forecast_mid_term"""
+
+    def test_get_solar_and_wind_forecast_mid_term_today(self):
+        df = self.iso.get_solar_and_wind_forecast_mid_term(date="today")
+
+        now = self.iso.now()
+
+        assert df["Publish Time"].min() == now.normalize()
+        assert df["Publish Time"].max() == (now).floor("H")
+
+        assert df["Interval Start"].min() <= now
+
+        time_in_future = pd.Timedelta(days=5)
+
+        assert df["Interval Start"].max() >= now + time_in_future
+
+        self._check_solar_and_wind_forecast(df, "MID_TERM")
+
+    def test_get_solar_and_wind_forecast_mid_term_latest(self):
+        latest = self.iso.get_solar_and_wind_forecast_mid_term(date="latest")
+
+        # Single publish time
+        assert (
+            latest["Publish Time"]
+            == (self.iso.now() - pd.Timedelta(minutes=10)).floor("H")
+        ).all()
+
+        self._check_solar_and_wind_forecast(latest, "MID_TERM")
+
+    def test_get_solar_and_wind_forecast_mid_term_historical(self):
+        now = self.iso.now()
+
+        three_days_ago = now.normalize() - pd.Timedelta(days=3)
+
+        df = self.iso.get_solar_and_wind_forecast_mid_term(date=three_days_ago)
+
+        assert (df["Publish Time"].unique() == three_days_ago).all()
+
+        # Each file contains data going back into the past
+        assert df["Interval Start"].min() <= three_days_ago
+        assert df["Interval Start"].max() >= three_days_ago + pd.Timedelta(days=6)
+
+        self._check_solar_and_wind_forecast(df, "MID_TERM")
 
     def test_get_solar_and_wind_forecast_mid_term_historical_with_date_range(self):
         now = self.iso.now()
@@ -593,28 +733,56 @@ class TestSPP(BaseTestISO):
         assert (df["Actual Wind MW"] >= 0).all()
         assert (df["Actual Solar MW"] >= 0).all()
 
-    def _check_solar_and_wind_forecast(self, df, forecast_type="MID_TERM"):
-        expected_cols = set(
-            [
-                "Interval Start",
-                "Interval End",
-                "Publish Time",
-                "Wind Forecast MW",
-                "Actual Wind MW",
-                "Solar Forecast MW",
-                "Actual Solar MW",
-            ],
+    def _check_load_forecast(self, df, forecast_type):
+        forecast_col = "STLF" if forecast_type == "SHORT_TERM" else "MTLF"
+        actual_col = "Actual" if forecast_type == "SHORT_TERM" else "Averaged Actual"
+
+        expected_cols = [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Forecast Type",
+            forecast_col,
+            actual_col,
+        ]
+
+        interval = (
+            pd.Timedelta(minutes=5)
+            if forecast_type == "SHORT_TERM"
+            else pd.Timedelta(hours=1)
         )
 
-        interval = pd.Timedelta(minutes=5)
+        assert df.columns.tolist() == expected_cols
+
+        assert (df[forecast_col] >= 0).all()
+
+        assert (df["Interval End"] - df["Interval Start"] == interval).all()
+
+        assert (df["Forecast Type"] == forecast_type).all()
+
+    def _check_solar_and_wind_forecast(self, df, forecast_type):
+        expected_cols = [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Forecast Type",
+            "Wind Forecast MW",
+            "Actual Wind MW",
+            "Solar Forecast MW",
+            "Actual Solar MW",
+        ]
 
         if forecast_type == "MID_TERM":
-            expected_cols -= {"Actual Wind MW", "Actual Solar MW"}
-            interval = pd.Timedelta(hours=1)
+            expected_cols.remove("Actual Wind MW")
+            expected_cols.remove("Actual Solar MW")
 
-        expected_cols.add("Forecast Type")
+        interval = (
+            pd.Timedelta(minutes=5)
+            if forecast_type == "SHORT_TERM"
+            else pd.Timedelta(hours=1)
+        )
 
-        assert set(df.columns.tolist()) == expected_cols
+        assert df.columns.tolist() == expected_cols
 
         assert (df["Wind Forecast MW"] >= 0).all()
         assert (df["Solar Forecast MW"] >= 0).all()

--- a/gridstatus/tests/test_spp.py
+++ b/gridstatus/tests/test_spp.py
@@ -352,10 +352,11 @@ class TestSPP(BaseTestISO):
         ],
     )
     def test_get_solar_and_wind_forecast_today(self, forecast_type):
-        df = self.iso.get_solar_and_wind_forecast(
-            date="today",
-            forecast_type=forecast_type,
+        method = getattr(
+            self.iso,
+            f"get_solar_and_wind_forecast_{forecast_type.lower()}",
         )
+        df = method(date="today")
 
         assert df["Interval Start"].min() <= pd.Timestamp.now(
             tz=self.iso.default_timezone,
@@ -378,25 +379,26 @@ class TestSPP(BaseTestISO):
 
     @pytest.mark.parametrize("forecast_type", ["MID_TERM", "SHORT_TERM"])
     def test_get_solar_and_wind_forecast_latest(self, forecast_type):
-        assert self.iso.get_solar_and_wind_forecast(
-            "latest",
-            forecast_type=forecast_type,
-        ).equals(
-            self.iso.get_solar_and_wind_forecast("today", forecast_type=forecast_type),
+        method = getattr(
+            self.iso,
+            f"get_solar_and_wind_forecast_{forecast_type.lower()}",
         )
+        assert method("latest").equals(method("today"))
 
     @pytest.mark.parametrize("forecast_type", ["MID_TERM", "SHORT_TERM"])
     def test_get_solar_and_wind_forecast_historical(self, forecast_type):
+        method = getattr(
+            self.iso,
+            f"get_solar_and_wind_forecast_{forecast_type.lower()}",
+        )
+
         three_days_ago = pd.Timestamp.now(
             tz=self.iso.default_timezone,
         ).normalize() - pd.Timedelta(
             days=3,
         )
 
-        df = self.iso.get_solar_and_wind_forecast(
-            date=three_days_ago,
-            forecast_type=forecast_type,
-        )
+        df = method(date=three_days_ago)
 
         time_in_future = (
             pd.Timedelta(days=5)

--- a/gridstatus/tests/test_spp.py
+++ b/gridstatus/tests/test_spp.py
@@ -342,6 +342,12 @@ class TestSPP(BaseTestISO):
     def test_get_load_forecast_historical_with_date_range(self):
         pass
 
+    """get_solar_and_wind_actuals"""
+    # TODO: Implement
+
+    """get_solar_and_wind_forecast"""
+    # TODO: Implement
+
     """get_status"""
 
     def test_get_status_latest(self):

--- a/gridstatus/tests/test_spp.py
+++ b/gridstatus/tests/test_spp.py
@@ -352,9 +352,8 @@ class TestSPP(BaseTestISO):
 
         now = self.iso.now()
 
-        assert (
-            df["Publish Time"].unique() == (now - pd.Timedelta(minutes=2)).floor("5T")
-        ).all()
+        assert df["Publish Time"].min() == now.normalize()
+        assert df["Publish Time"].max() == (now).floor("5T")
 
         assert df["Interval Start"].min() <= now
 
@@ -364,14 +363,24 @@ class TestSPP(BaseTestISO):
 
         self._check_solar_and_wind_forecast(df, "SHORT_TERM")
 
+    def test_get_solar_and_wind_forecast_short_term_latest(self):
+        latest = self.iso.get_solar_and_wind_forecast_short_term(date="latest")
+
+        # Single publish time
+        assert (
+            latest["Publish Time"]
+            == (self.iso.now() - pd.Timedelta(minutes=2)).floor("5T")
+        ).all()
+
+        self._check_solar_and_wind_forecast(latest, "SHORT_TERM")
+
     def test_get_solar_and_wind_forecast_mid_term_today(self):
         df = self.iso.get_solar_and_wind_forecast_mid_term(date="today")
 
         now = self.iso.now()
 
-        assert (
-            df["Publish Time"].unique() == (now - pd.Timedelta(minutes=10)).floor("H")
-        ).all()
+        assert df["Publish Time"].min() == now.normalize()
+        assert df["Publish Time"].max() == (now).floor("H")
 
         assert df["Interval Start"].min() <= now
 
@@ -381,15 +390,16 @@ class TestSPP(BaseTestISO):
 
         self._check_solar_and_wind_forecast(df, "MID_TERM")
 
-    def test_get_solar_and_wind_forecast_short_term_latest(self):
-        assert self.iso.get_solar_and_wind_forecast_short_term(date="latest").equals(
-            self.iso.get_solar_and_wind_forecast_short_term(date="today"),
-        )
-
     def test_get_solar_and_wind_forecast_mid_term_latest(self):
-        assert self.iso.get_solar_and_wind_forecast_mid_term(date="latest").equals(
-            self.iso.get_solar_and_wind_forecast_mid_term(date="today"),
-        )
+        latest = self.iso.get_solar_and_wind_forecast_mid_term(date="latest")
+
+        # Single publish time
+        assert (
+            latest["Publish Time"]
+            == (self.iso.now() - pd.Timedelta(minutes=10)).floor("H")
+        ).all()
+
+        self._check_solar_and_wind_forecast(latest, "MID_TERM")
 
     def test_get_solar_and_wind_forecast_short_term_historical(self):
         now = self.iso.now()


### PR DESCRIPTION
- Adds SPP solar and wind short term and mid term forecasts
  - Short term from https://portal.spp.org/pages/shortterm-resource-forecast
  - Mid term from https://portal.spp.org/pages/midterm-resource-forecast
- Forecasts available in 5-minute intervals up to 4 hours in the future and hourly intervals up to 7 days in the future
- Adds SPP short term and mid term load forecasts
  - Short term from https://portal.spp.org/pages/stlf-vs-actual
  - Mid term from https://portal.spp.org/pages/mtlf-vs-actual
- Load forecasts available in 5-minute intervals for past 15 minutes (not future) and hourly intervals up to 7 days in the future