### PR TITLE
EIA client parse total returned rows as int

### DIFF
--- a/gridstatus/eia.py
+++ b/gridstatus/eia.py
@@ -53,7 +53,7 @@ class EIA:
         data = self.session.get(url, headers=headers)
         response = data.json()["response"]
         df = pd.DataFrame(response["data"])
-        return df, response["total"]
+        return df, int(response["total"])
 
     def get_dataset(self, dataset, start, end, n_workers=1, verbose=False):
         """Get data from a dataset


### PR DESCRIPTION
Something must have changed with EIA api to cause this to break. updated now