### PR TITLE
Fix Read the Docs Build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,29 +1,23 @@
 # .readthedocs.yaml
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details.
+# This specific version is copied from https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry with modifications
 version: 2
-
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  configuration: docs/conf.py
-
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: []
 
 build:
   os: "ubuntu-22.04"
   tools:
     python: "3.10"
   jobs:
-    # https://docs.readthedocs.io/en/latest/build-customization.html#install-dependencies-with-poetry
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
     post_install:
-      # Install all dependencies including those for building the docs
-      - poetry install --all-extras
+      # Install dependencies with all dependencies
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --all-extras
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
- This attempts to fix the failing read the docs build (https://readthedocs.org/projects/isodata/builds/) by downgrading sphinx
