### PR TITLE
Implement Retries for BaseISO._get_json

### DIFF
--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -75,6 +75,21 @@ class ISOBase:
     interconnection_homepage = None
 
     def _get_json(self, url, verbose=False, retries=None, **kwargs):
+        """
+        Makes a get request to the given url and returns the json response. Optionally
+        retries the request if it fails.
+
+        Args:
+            url (str): The URL to request
+            verbose (bool): Whether to print log messages
+            retries (int): The number of retries to attempt if the request fails. The
+                total tries will be 1 + retries
+            **kwargs: Additional keyword arguments to pass to requests.get
+
+        Returns:
+            dict: The JSON response from the request if successful. Otherwise, raises
+                a requests.RequestException
+        """
         max_attempts = 1 if retries is None else retries + 1
         attempt = 0
         while attempt < max_attempts:

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -16,6 +16,9 @@ from gridstatus.decorators import (
 from gridstatus.gs_logging import log
 from gridstatus.lmp_config import lmp_config
 
+# PJM requires retries because the API is flaky
+DEFAULT_RETRIES = 3
+
 
 class PJM(ISOBase):
     """PJM"""
@@ -27,9 +30,6 @@ class PJM(ISOBase):
     interconnection_homepage = (
         "https://www.pjm.com/planning/service-requests/services-request-status"
     )
-
-    # PJM requires retries because the API is flaky
-    retries = 3
 
     location_types = [
         "ZONE",
@@ -411,6 +411,10 @@ class PJM(ISOBase):
         "93353963",
         "93353965",
     ]
+
+    def __init__(self, retries=DEFAULT_RETRIES):
+        self.retries = retries
+        super().__init__()
 
     markets = [
         Markets.REAL_TIME_5_MIN,

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -28,6 +28,9 @@ class PJM(ISOBase):
         "https://www.pjm.com/planning/service-requests/services-request-status"
     )
 
+    # PJM requires retries because the API is flaky
+    retries = 3
+
     location_types = [
         "ZONE",
         "LOAD",
@@ -884,8 +887,11 @@ class PJM(ISOBase):
         log(msg, verbose)
 
         api_key = self._get_key()
+
         r = self._get_json(
             "https://api.pjm.com/api/v1/" + endpoint,
+            verbose=verbose,
+            retries=self.retries,
             params=final_params,
             headers={"Ocp-Apim-Subscription-Key": api_key},
         )
@@ -906,6 +912,8 @@ class PJM(ISOBase):
                 next_url = [x for x in r["links"] if x["rel"] == "next"][0]["href"]
                 r = self._get_json(
                     next_url,
+                    verbose=verbose,
+                    retries=self.retries,
                     headers={
                         "Ocp-Apim-Subscription-Key": api_key,
                     },
@@ -1030,6 +1038,7 @@ class PJM(ISOBase):
     def _get_key(self):
         settings = self._get_json(
             "https://dataminer2.pjm.com/config/settings.json",
+            verbose=False,
         )
 
         return settings["subscriptionKey"]

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -1036,6 +1036,7 @@ class PJM(ISOBase):
         return queue
 
     def _get_key(self):
+        # Not using retries here, should we be?
         settings = self._get_json(
             "https://dataminer2.pjm.com/config/settings.json",
             verbose=False,

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -840,7 +840,7 @@ class SPP(ISOBase):
             "returnGeometry": "false",
             "outFields": "*",
         }
-        doc = self._get_json(base_url, params=args, verbose=verbose)
+        doc = self._get_json(base_url, verbose=verbose, params=args)
         df = pd.DataFrame([feature["attributes"] for feature in doc["features"]])
         return df
 

--- a/gridstatus/tests/test_base.py
+++ b/gridstatus/tests/test_base.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from gridstatus.base import ISOBase
+
+
+class TestISOBase:
+    # Test Case 1: Successful request without retry
+    def test_get_json_successful(self):
+        # Have to mock the module where the requests.get method is called
+        with patch("gridstatus.base.requests.get") as mocked_get:
+            mocked_get.return_value.json.return_value = {"key": "value"}
+            mocked_get.return_value.raise_for_status = Mock()
+
+            iso = ISOBase()
+            response = iso._get_json("http://example.com", False)
+            assert response == {"key": "value"}
+            mocked_get.assert_called_once()
+
+    # Test Case 2: Successful request on a retry
+    def test_get_json_success_after_retry(self):
+        with patch("gridstatus.base.requests.get") as mocked_get:
+            mocked_get.side_effect = [
+                requests.RequestException("Error"),
+                Mock(json=Mock(return_value={"key": "value"}), raise_for_status=Mock()),
+            ]
+
+            iso = ISOBase()
+            response = iso._get_json("http://example.com", False, retries=1)
+            assert response == {"key": "value"}
+            assert mocked_get.call_count == 2
+
+    # Test Case 3: Exhaust retries and raise exception
+    def test_get_json_exhaust_retries(self):
+        with patch("gridstatus.base.requests.get") as mocked_get:
+            mocked_get.side_effect = requests.RequestException("Error")
+
+            iso = ISOBase()
+            with pytest.raises(requests.RequestException):
+                iso._get_json("http://example.com", False, retries=2)
+            # Total of 3 calls (1 original + 2 retries)
+            assert mocked_get.call_count == 3
+
+    # Test Case 4: No retries (retries is None)
+    def test_get_json_no_retries(self):
+        with patch("gridstatus.base.requests.get") as mocked_get:
+            mocked_get.side_effect = requests.RequestException("Error")
+
+            iso = ISOBase()
+            with pytest.raises(requests.RequestException):
+                iso._get_json("http://example.com", False, retries=None)
+            mocked_get.assert_called_once()


### PR DESCRIPTION
- Implements retries for `BaseISO._get_json` which are sent to 0 by default
- Sets `pjm` data retrieval methods to use retries due to the high rate of 503 errors seen with this API
