### PR TITLE
Add Interval Start and Interval End to ERCOT SCED Datasets

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -967,6 +967,8 @@ class Ercot(ISOBase):
 
         df = df[
             [
+                "Interval Start",
+                "Interval End",
                 "SCED Timestamp",
                 "Market",
                 "Location",
@@ -2045,6 +2047,12 @@ class Ercot(ISOBase):
             self.default_timezone,
             ambiguous=df["RepeatedHourFlag"] == "N",
         )
+
+        # SCED runs at least every 5 minutes. These values are only approximations,
+        # not exact.
+        # Round to nearest 5 minutes
+        df["Interval Start"] = df["SCED Timestamp"].dt.round("5min")
+        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
 
         df = df.drop("RepeatedHourFlag", axis=1)
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1928,7 +1928,7 @@ class Ercot(ISOBase):
             else:
                 df_offers_hourly = (
                     df_offers.groupby(["Delivery Date", "Hour Ending"])
-                    .apply(_make_bid_curve)
+                    .apply(_make_bid_curve, include_groups=False)
                     .reset_index(name=name)
                 )
             all_dfs.append(df_offers_hourly)
@@ -2087,7 +2087,7 @@ class Ercot(ISOBase):
         )
 
         df.sort_values("SCED Timestamp", inplace=True)
-        return df
+        return df[["Interval Start", "Interval End", "SCED Timestamp", "System Lambda"]]
 
     @support_date_range("DAY_START")
     def get_highest_price_as_offer_selected(self, date, verbose=False):
@@ -2147,7 +2147,7 @@ class Ercot(ISOBase):
                     "Block Indicator",
                 ],
             )
-            .apply(_handle_offers)
+            .apply(_handle_offers, include_groups=False)
             .reset_index()
         )
 

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -83,6 +83,8 @@ class TestErcot(BaseTestISO):
             df = self.iso.get_sced_system_lambda(i, verbose=True)
             assert df.shape[0] >= 0
             assert df.columns.tolist() == [
+                "Interval Start",
+                "Interval End",
                 "SCED Timestamp",
                 "System Lambda",
             ]
@@ -1123,7 +1125,7 @@ class TestErcot(BaseTestISO):
         assert df.shape[0] >= 0
         assert df.columns.tolist() == cols
 
-        assert (df["Interval Start"] == df["SCED Timestamp"].dt.round("5m")).all()
+        assert (df["Interval Start"] == df["SCED Timestamp"].dt.round("5min")).all()
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
         ).all()

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -1068,6 +1068,8 @@ class TestErcot(BaseTestISO):
 
     def test_get_lmp_electrical_bus(self):
         cols = [
+            "Interval Start",
+            "Interval End",
             "SCED Timestamp",
             "Market",
             "Location",
@@ -1109,6 +1111,8 @@ class TestErcot(BaseTestISO):
         )
 
         cols = [
+            "Interval Start",
+            "Interval End",
             "SCED Timestamp",
             "Market",
             "Location",
@@ -1118,6 +1122,11 @@ class TestErcot(BaseTestISO):
 
         assert df.shape[0] >= 0
         assert df.columns.tolist() == cols
+
+        assert (df["Interval Start"] == df["SCED Timestamp"].dt.round("5m")).all()
+        assert (
+            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
+        ).all()
 
     def test_read_docs_return_empty_df(self):
         df = self.iso.read_docs(docs=[], empty_df=pd.DataFrame(columns=["test"]))


### PR DESCRIPTION
- Adds "Interval Start" and "Interval End" to ERCOT SCED datasets
- "Interval Start" is "SCED Timestamp" rounded to the nearest 5 minutes
- "Interval End" is "Interval Start" + 5 minutes
