### PR TITLE
Add withdrawn projects to SPP interconnection data

### DIFF
--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -416,6 +416,8 @@ class NYISO(ISOBase):
         withdrawn["Withdrawal Comment"] = None
         withdrawn = withdrawn.rename(columns={"Utility ": "Utility"})
 
+        withdrawn = withdrawn.rename(columns={"Owner/Developer": "Developer Name"})
+
         # make completed look like the other two sheets
         completed = pd.read_excel(excel_file, sheet_name="In Service", header=[0, 1])
         completed.insert(15, "SGIA Tender Date", None)
@@ -541,7 +543,7 @@ class NYISO(ISOBase):
             "Project Name": "Project Name",
             "County": "County",
             "State": "State",
-            "Owner/Developer": "Interconnecting Entity",
+            "Developer Name": "Interconnecting Entity",
             "Utility": "Transmission Owner",
             "Interconnection Point": "Interconnection Location",
             "Status": "Status",

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -712,6 +712,7 @@ class SPP(ISOBase):
         queue["Status (Original)"] = queue["Status"]
         completed_val = InterconnectionQueueStatus.COMPLETED.value
         active_val = InterconnectionQueueStatus.ACTIVE.value
+        withdrawn_val = InterconnectionQueueStatus.WITHDRAWN.value
         queue["Status"] = queue["Status"].map(
             {
                 "IA FULLY EXECUTED/COMMERCIAL OPERATION": completed_val,
@@ -720,6 +721,7 @@ class SPP(ISOBase):
                 "IA PENDING": active_val,
                 "DISIS STAGE": active_val,
                 "None": active_val,
+                "WITHDRAWN": withdrawn_val,
             },
         )
 
@@ -741,6 +743,7 @@ class SPP(ISOBase):
             "Generation Type": "Generation Type",
             "Request Received": "Queue Date",
             "Substation or Line": "Interconnection Location",
+            "Date Withdrawn": "Withdrawn Date",
         }
 
         # todo: there are a few columns being parsed
@@ -759,7 +762,6 @@ class SPP(ISOBase):
         missing = [
             "Project Name",
             "Interconnecting Entity",
-            "Withdrawn Date",
             "Withdrawal Comment",
             "Actual Completion Date",
         ]

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -694,7 +694,7 @@ class SPP(ISOBase):
     # 15mb file with five minute resolution
 
     def get_raw_interconnection_queue(self, verbose=False) -> BinaryIO:
-        url = "https://opsportal.spp.org/Studies/GenerateActiveCSV"
+        url = "https://opsportal.spp.org/Studies/GenerateSummaryCSV"
         msg = f"Getting interconnection queue from {url}"
         log(msg, verbose)
         response = requests.get(url)
@@ -705,8 +705,6 @@ class SPP(ISOBase):
 
         Returns:
             pandas.DataFrame: Interconnection queue
-
-
         """
         raw_data = self.get_raw_interconnection_queue(verbose)
         queue = pd.read_csv(raw_data, skiprows=1)


### PR DESCRIPTION
This PR:

- Updates the SPP interconnection queue to include withdrawn projects
- Fixes a bug in the NYISO interconnection queue cleaning that resulted in missing developer information.