### PR TITLE
Ercot Get Reported Outages

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1808,8 +1808,11 @@ class Ercot(ISOBase):
         Data available at
         https://www.ercot.com/api/1/services/read/dashboards/generation-outages.json
 
-        This data is ephemeral and only available for the current and previous days
+        This data is ephemeral in that there is only one file available that is
+        constantly updated. There is no historical data.
         """
+
+        log("Downloading ERCOT reported outages data", verbose=verbose)
 
         json = requests.get(
             "https://www.ercot.com/api/1/services/read/dashboards/generation-outages.json",  # noqa: E501

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -820,6 +820,45 @@ class TestErcot(BaseTestISO):
 
         assert df.columns.tolist() == cols
 
+    """get_reported_outages"""
+
+    def test_get_reported_outages(self):
+        df = self.iso.get_reported_outages()
+
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Combined Unplanned",
+            "Combined Planned",
+            "Combined Total",
+            "Dispatchable Unplanned",
+            "Dispatchable Planned",
+            "Dispatchable Total",
+            "Renewable Unplanned",
+            "Renewable Planned",
+            "Renewable Total",
+        ]
+
+        assert df["Interval Start"].min() <= self.local_start_of_today() - pd.Timedelta(
+            days=6,
+        )
+
+        assert df["Interval Start"].max() >= self.local_start_of_today()
+
+        assert (
+            df["Combined Total"] == (df["Combined Unplanned"] + df["Combined Planned"])
+        ).all()
+
+        assert (
+            df["Dispatchable Total"]
+            == (df["Dispatchable Unplanned"] + df["Dispatchable Planned"])
+        ).all()
+
+        assert (
+            df["Renewable Total"]
+            == (df["Renewable Unplanned"] + df["Renewable Planned"])
+        ).all()
+
     def test_get_hourly_resource_outage_capacity(self):
         cols = [
             "Publish Time",

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -826,9 +826,7 @@ class TestErcot(BaseTestISO):
         df = self.iso.get_reported_outages()
 
         assert df.columns.tolist() == [
-            "Interval Start",
-            "Interval End",
-            "Combined Unplanned",
+            "Time" "Combined Unplanned",
             "Combined Planned",
             "Combined Total",
             "Dispatchable Unplanned",
@@ -839,11 +837,11 @@ class TestErcot(BaseTestISO):
             "Renewable Total",
         ]
 
-        assert df["Interval Start"].min() <= self.local_start_of_today() - pd.Timedelta(
+        assert df["Time"].min() <= self.local_start_of_today() - pd.Timedelta(
             days=6,
         )
 
-        assert df["Interval Start"].max() >= self.local_start_of_today()
+        assert df["Time"].max() >= self.local_start_of_today()
 
         assert (
             df["Combined Total"] == (df["Combined Unplanned"] + df["Combined Planned"])
@@ -858,6 +856,8 @@ class TestErcot(BaseTestISO):
             df["Renewable Total"]
             == (df["Renewable Unplanned"] + df["Renewable Planned"])
         ).all()
+
+    """get_hourly_resource_outage_capacity"""
 
     def test_get_hourly_resource_outage_capacity(self):
         cols = [


### PR DESCRIPTION
- Adds reported outages that feeds the dashboard at https://www.ercot.com/gridmktinfo/dashboards/generationoutages
- Data is actual values over the past 6 days in 5 minute intervals
