### PR TITLE
Ercot Forecasts Use HTML For Yesterday as Well

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -423,7 +423,10 @@ class Ercot(ISOBase):
             pandas.DataFrame
 
         """
-        if utils.is_today(date, tz=self.default_timezone):
+        if utils.is_today(date, tz=self.default_timezone) or utils.is_yesterday(
+            date,
+            tz=self.default_timezone,
+        ):
             df = self._get_weather_zone_load_html(date, verbose=verbose)
         else:
             doc_info = self._get_document(
@@ -449,7 +452,13 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame
         """
-        if utils.is_today(date, tz=self.default_timezone):
+        # Use the html page for both today and yesterday to ensure all the
+        # data is retrieved. The html page is updated every hour at 20 mins
+        # past the hour but the report is only published once per dat at 0550 UTC.
+        if utils.is_today(date, tz=self.default_timezone) or utils.is_yesterday(
+            date,
+            tz=self.default_timezone,
+        ):
             df = self._get_forecast_zone_load_html(date, verbose=verbose)
         else:
             doc_info = self._get_document(

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -423,6 +423,9 @@ class Ercot(ISOBase):
             pandas.DataFrame
 
         """
+        # Use the html page for both today and yesterday to ensure all the
+        # data is retrieved. The html page is updated every hour at 20 mins
+        # past the hour but the report is only published once per dat at 0550 UTC.
         if utils.is_today(date, tz=self.default_timezone) or utils.is_yesterday(
             date,
             tz=self.default_timezone,
@@ -453,8 +456,7 @@ class Ercot(ISOBase):
             pandas.DataFrame
         """
         # Use the html page for both today and yesterday to ensure all the
-        # data is retrieved. The html page is updated every hour at 20 mins
-        # past the hour but the report is only published once per dat at 0550 UTC.
+        # data is retrieved.
         if utils.is_today(date, tz=self.default_timezone) or utils.is_yesterday(
             date,
             tz=self.default_timezone,

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -826,7 +826,8 @@ class TestErcot(BaseTestISO):
         df = self.iso.get_reported_outages()
 
         assert df.columns.tolist() == [
-            "Time" "Combined Unplanned",
+            "Time",
+            "Combined Unplanned",
             "Combined Planned",
             "Combined Total",
             "Dispatchable Unplanned",
@@ -838,7 +839,9 @@ class TestErcot(BaseTestISO):
         ]
 
         assert df["Time"].min() <= self.local_start_of_today() - pd.Timedelta(
+            # Add the minutes because the times do not line up exactly on the hour
             days=6,
+            minutes=-5,
         )
 
         assert df["Time"].max() >= self.local_start_of_today()

--- a/gridstatus/tests/test_utils.py
+++ b/gridstatus/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 import gridstatus
-from gridstatus.utils import is_dst_end
+from gridstatus.utils import is_dst_end, is_today, is_yesterday
 
 
 def test_is_dst_end():
@@ -17,3 +17,61 @@ def test_is_dst_end():
         tz=gridstatus.NYISO.default_timezone,
     )
     assert not is_dst_end(dst_start)
+
+
+def test_is_today():
+    utc_start_of_today = pd.Timestamp.utcnow().normalize()
+    assert not is_today(utc_start_of_today, tz="America/New_York")
+    assert not is_today(
+        utc_start_of_today + pd.Timedelta(hours=2),
+        tz="America/New_York",
+    )
+    assert is_today(utc_start_of_today + pd.Timedelta(hours=6), tz="America/New_York")
+    assert not is_today(
+        utc_start_of_today - pd.Timedelta(hours=6),
+        tz="America/New_York",
+    )
+
+    assert not is_today(utc_start_of_today, tz="America/Chicago")
+    assert not is_today(
+        utc_start_of_today + pd.Timedelta(hours=3),
+        tz="America/Chicago",
+    )
+    assert is_today(utc_start_of_today + pd.Timedelta(hours=6), tz="America/Chicago")
+    assert not is_today(
+        utc_start_of_today - pd.Timedelta(hours=5),
+        tz="America/Chicago",
+    )
+
+
+def test_is_yesterday():
+    utc_start_of_yesterday = pd.Timestamp.utcnow().normalize() - pd.Timedelta("1 day")
+
+    assert not is_yesterday(utc_start_of_yesterday, tz="America/New_York")
+    assert not is_yesterday(
+        utc_start_of_yesterday + pd.Timedelta(hours=2),
+        tz="America/New_York",
+    )
+    assert is_yesterday(
+        utc_start_of_yesterday + pd.Timedelta(hours=6),
+        tz="America/New_York",
+    )
+    assert not is_yesterday(
+        utc_start_of_yesterday - pd.Timedelta(hours=6),
+        tz="America/New_York",
+    )
+
+    assert not is_yesterday(utc_start_of_yesterday, tz="America/Chicago")
+    assert not is_yesterday(
+        utc_start_of_yesterday + pd.Timedelta(hours=3),
+        tz="America/Chicago",
+    )
+
+    assert is_yesterday(
+        utc_start_of_yesterday + pd.Timedelta(hours=6),
+        tz="America/Chicago",
+    )
+    assert not is_yesterday(
+        utc_start_of_yesterday - pd.Timedelta(hours=5),
+        tz="America/Chicago",
+    )

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -232,6 +232,12 @@ def is_today(date, tz):
     return _handle_date(date, tz=tz).date() == pd.Timestamp.now(tz=tz).date()
 
 
+def is_yesterday(date, tz):
+    return _handle_date(date, tz=tz).date() == (
+        pd.Timestamp.now(tz=tz).date() - pd.Timedelta(days=1)
+    )
+
+
 def is_within_last_days(date, days, tz):
     """Returns whether date is within N days"""
     now = pd.Timestamp.now(tz=tz).date()


### PR DESCRIPTION
- Use the HTML report for `get_load_by_forecast_zone` and `get_load_by_weather_zone` for yesterday as well as today.
- Required because the HTML reports are updated every hour while the EMIL report is only published once a day. This creates
a situation where we can miss data if we request the EMIL report before it is available and before we have retrieved all the
data from the HTML report
