### PR TITLE
PJM Historical Load Forecast

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -632,7 +632,9 @@ class PJM(ISOBase):
             ]
         ]
 
-        return data
+        return data.sort_values(["Interval Start", "Publish Time"]).reset_index(
+            drop=True,
+        )
 
     # todo https://dataminer2.pjm.com/feed/load_frcstd_hist/definition
     # def get_historical_forecast(self, date):

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -216,13 +216,43 @@ class TestPJM(BaseTestISO):
 
     """get_load_forecast"""
 
-    def test_get_load_forecast_historical(self):
-        with pytest.raises(NotSupported):
-            super().test_get_load_forecast_historical()
+    load_forecast_columns = [
+        "Time",
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "Load Forecast",
+    ]
 
-    @pytest.mark.skip(reason="Not Applicable")
+    def test_get_load_forecast_historical(self):
+        start_date = "2023-05-01"
+        df = self.iso.get_load_forecast(start_date)
+
+        assert df.columns.tolist() == self.load_forecast_columns
+        assert df["Interval Start"].min() == self.local_start_of_day(start_date)
+
+        assert df["Interval End"].max() == self.local_start_of_day(
+            start_date,
+            # End is inclusive in this case
+        ) + pd.Timedelta(days=1, hours=1)
+
+        assert df["Interval Start"].value_counts().max() == 10
+        assert df["Publish Time"].nunique() == 10
+
     def test_get_load_forecast_historical_with_date_range(self):
-        pass
+        start_date = "2022-10-17"
+        end_date = "2022-10-22"
+
+        df = self.iso.get_load_forecast(start_date, end_date)
+
+        assert df.columns.tolist() == self.load_forecast_columns
+        assert df["Interval Start"].min() == self.local_start_of_day(start_date)
+        assert df["Interval End"].max() == self.local_start_of_day(
+            end_date,
+        ) + pd.Timedelta(hours=1)
+
+        assert df["Interval Start"].value_counts().max() == 10
+        assert df["Publish Time"].nunique() == 10 * 3
 
     """get_pnode_ids"""
 

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -98,6 +98,9 @@ def make_availability_table():
 
 
 def _handle_date(date, tz=None):
+    if date is None:
+        return date
+
     if date == "today":
         date = pd.Timestamp.now(tz=tz).normalize()
 


### PR DESCRIPTION
- Adds historical load forecast for PJM using https://dataminer2.pjm.com/feed/load_frcstd_hist/definition
- This historical forecast includes all vintages (10 forecasts for each interval)
