### PR TITLE
Flip Sign on NYISO Congestion to be Consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added more methods to the `ErcotAPI` class which uses the new [Ercot API](https://data.ercot.com/) for fetching data
   - Eventually, the `ErcotAPI` will be the primary way to fetch data from ERCOT, but for now, we still need the `Ercot` class because the new API doesn't support all datasets.
 - Add `pjm.get_gen_outages_by_type` to get generation outage data
+- Flips the congestion sign on NYISO to be consistent with other ISOs. In the NYISO raw data, a negative congestion value means a higher LMP, which is the opposite of other ISOs. We flip the sign so that a negative congestion value means a lower LMP as it does in other ISOs.
 
 ## v0.28.0 - Mar 20, 2024
 

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -316,7 +316,8 @@ class NYISO(ISOBase):
 
         # In NYISO raw data, a negative congestion number means a higher LMP. We
         # flip the sign to make it consistent with other ISOs where a negative
-        # congestion number means a lower LMP.
+        # congestion number means a lower LMP. Thus, LMP = Energy + Loss + Congestion
+        # for NYISO, as in other ISOs.
         df["Congestion"] *= -1
         df["Energy"] = df["LMP"] - df["Loss"] - df["Congestion"]
         df["Market"] = market.value

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -314,7 +314,11 @@ class NYISO(ISOBase):
 
         df = df.rename(columns=columns)
 
-        df["Energy"] = df["LMP"] - (df["Loss"] - df["Congestion"])
+        # In NYISO raw data, a negative congestion number means a higher LMP. We
+        # flip the sign to make it consistent with other ISOs where a negative
+        # congestion number means a lower LMP.
+        df["Congestion"] *= -1
+        df["Energy"] = df["LMP"] - df["Loss"] - df["Congestion"]
         df["Market"] = market.value
         df["Location Type"] = "Zone" if location_type == ZONE else "Generator"
 


### PR DESCRIPTION
- Flip the sign on NYISO congestion component of LMP to be consistent with other ISOs
