### PR TITLE
Fixes ISONE LMP Real Time 5 Min When No Intervals are Selected

### DIFF
--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -392,7 +392,6 @@ class ISONE(ISOBase):
         Find Node ID mapping:
             https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/
         """  # noqa
-
         if date == "latest":
             return self._get_latest_lmp(
                 market=market,
@@ -406,6 +405,7 @@ class ISONE(ISOBase):
             locations = "ALL"
 
         now = pd.Timestamp.now(tz=self.default_timezone)
+
         if market == Markets.REAL_TIME_5_MIN:
             intervals = self.lmp_real_time_intervals[:]
 
@@ -458,7 +458,7 @@ class ISONE(ISOBase):
                     verbose=verbose,
                 )
 
-                if data:
+                if data is not None:
                     data_current = data_current[
                         data_current["Local Time"] > data["Local Time"].max()
                     ]

--- a/gridstatus/tests/test_isone.py
+++ b/gridstatus/tests/test_isone.py
@@ -121,6 +121,23 @@ class TestISONE(BaseTestISO):
             verbose=VERBOSE,
         )
 
+    def test_get_lmp_real_time_no_intervals_gets_current_data(self):
+        # Make sure when there are no intervals to fetch, the method still
+        # fetches the current data.
+        date = self.local_now().normalize() + pd.DateOffset(hours=2)
+        end = date + pd.DateOffset(hours=1)
+
+        df = self.iso.get_lmp(
+            (date, end),
+            market=Markets.REAL_TIME_5_MIN,
+            verbose=VERBOSE,
+        )
+
+        assert df["Interval Start"].min() == self.local_start_of_today()
+        assert df["Interval Start"].max() >= self.local_start_of_today() + pd.Timedelta(
+            minutes=5,
+        )
+
     """get_load"""
 
     @pytest.mark.parametrize("date", DST_BOUNDARIES)


### PR DESCRIPTION
- Fixes the ISONE LMP Real Time 5 Minute data fetching when no intervals are selected by still getting current data
- This can happen when the `date` and `end` are < 4 hours apart
