### PR TITLE
Fix ERCOT AS Plan before ECRS

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1430,6 +1430,10 @@ class Ercot(ISOBase):
             values="Quantity",
         ).reset_index()
 
+        # ECRS went live 2023-06-10 and isn't present in the data before then
+        if "ECRS" not in df.columns:
+            df["ECRS"] = pd.NA
+
         # Put ECRS at the end to match as_prices
         df = utils.move_cols_to_front(
             df,

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1430,6 +1430,11 @@ class Ercot(ISOBase):
             values="Quantity",
         ).reset_index()
 
+        # For some hours where there are no values, the data has "Not Applicable"
+        # which becomes a column in the pivot. We want to drop this column
+        if "Not Applicable" in df.columns:
+            df = df.drop(columns=["Not Applicable"])
+
         # ECRS went live 2023-06-10 and isn't present in the data before then
         if "ECRS" not in df.columns:
             df["ECRS"] = pd.NA

--- a/gridstatus/tests/test_ercot_api.py
+++ b/gridstatus/tests/test_ercot_api.py
@@ -408,6 +408,11 @@ class TestErcotAPI(TestHelperMixin):
             # Earlier files only contain two days of data
         ) + pd.DateOffset(days=2)
 
+        # First date of data
+        date = "2010-12-29"
+        df = self.iso.get_as_plan(date)
+        self._check_as_plan(df)
+
     """get_lmp_by_settlement_point"""
 
     def _check_lmp_by_settlement_point(self, df):

--- a/gridstatus/tests/test_ercot_api.py
+++ b/gridstatus/tests/test_ercot_api.py
@@ -371,6 +371,8 @@ class TestErcotAPI(TestHelperMixin):
 
         assert df["Publish Time"].dt.date.unique().tolist() == [date]
 
+        assert df["ECRS"].notna().any()
+
     def test_get_as_plan_historical_date_range(self):
         start_date = self.local_today() - pd.Timedelta(days=30)
         end_date = start_date + pd.Timedelta(days=2)
@@ -389,6 +391,22 @@ class TestErcotAPI(TestHelperMixin):
             start_date,
             (start_date + pd.DateOffset(days=1)).date(),
         ]
+
+    def test_get_as_plan_before_ecrs(self):
+        # Check that we add an ECRS column of nulls if it's not present
+        date = "2012-05-01"
+
+        df = self.iso.get_as_plan(date)
+
+        self._check_as_plan(df)
+
+        assert df["ECRS"].isna().all()
+
+        assert df["Interval Start"].min() == self.local_start_of_day(date)
+        assert df["Interval End"].max() == self.local_start_of_day(
+            date,
+            # Earlier files only contain two days of data
+        ) + pd.DateOffset(days=2)
 
     """get_lmp_by_settlement_point"""
 


### PR DESCRIPTION
- Fixes `ErcotAPI().get_as_plan()` for dates before ECRS went into service (2023-06-10)
