### PR TITLE
ERCOT Unplanned Resource Outages Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Eventually, the `ErcotAPI` will be the primary way to fetch data from ERCOT, but for now, we still need the `Ercot` class because the new API doesn't support all datasets.
 - Add `pjm.get_gen_outages_by_type` to get generation outage data
 - Flips the congestion sign on NYISO to be consistent with other ISOs. In the NYISO raw data, a negative congestion value means a higher LMP, which is the opposite of other ISOs. We flip the sign so that a negative congestion value means a lower LMP as it does in other ISOs.
+- Adds ERCOT unplanned system outages (`ERCOT().get_unplanned_system_outages`)
 
 ## v0.28.0 - Mar 20, 2024
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1,4 +1,5 @@
 import io
+import time
 from dataclasses import dataclass
 from enum import Enum
 from zipfile import ZipFile
@@ -2834,7 +2835,8 @@ class Ercot(ISOBase):
         Returns:
             list of Document with URL and Publish Date
         """
-        url = f"https://www.ercot.com/misapp/servlets/IceDocListJsonWS?reportTypeId={report_type_id}"  # noqa
+        # Include a cache buster to ensure we get the latest data
+        url = f"https://www.ercot.com/misapp/servlets/IceDocListJsonWS?reportTypeId={report_type_id}&_{int(time.time())}"  # noqa
 
         msg = f"Fetching document {url}"
         log(msg, verbose)


### PR DESCRIPTION
- Adds `Publish Time` to ERCOT unplanned resource outages
- Renames `Report Time` to `Current As Of` to better reflect what this column represents
