### PR TITLE
Fix ISONE LMP Real Time 5 Minute Date Span Issue

### DIFF
--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -465,6 +465,10 @@ class ISONE(ISOBase):
 
                     data = pd.concat([data, data_current])
                 else:
+                    # Only keep data from today
+                    data_current = data_current[
+                        data_current["Local Time"].dt.date == now.date()
+                    ]
                     data = data_current.copy()
 
             data = data.rename(columns={"Local Time": "Interval Start"})


### PR DESCRIPTION
- Fixes an issue where ISONE `get_lmp` could return duplicates when querying for real time 5 minute data with a start and end date spanning multiple days and the end date is the current date
- The fix is to limit the rolling 4 hour data to data from the current date to prevent overlap with data from the previous day
