### PR TITLE
Update How ERCOT Unplanned Resource Outages Handles Date Parameter

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -2067,10 +2067,12 @@ class Ercot(ISOBase):
     def get_unplanned_resource_outages(self, date, verbose=False):
         """Get Unplanned Resource Outages.
 
-        Data published at ~5am central on the 3rd day after the day of interest.
+        Data published at ~5am central on the 3rd day after the day of interest. Since
+        the date argument is the publish date, if you want to get data for a specific
+        date, pass in the date of interest - 3 days.
 
         Arguments:
-            date (str, datetime): date to get data for
+            date (str, datetime): publish date of the report
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
@@ -2079,7 +2081,7 @@ class Ercot(ISOBase):
         """
         doc = self._get_document(
             report_type_id=UNPLANNED_RESOURCE_OUTAGES_REPORT_RTID,
-            date=date.normalize() + pd.DateOffset(days=3),
+            date=date.normalize(),
             verbose=verbose,
         )
 

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -808,28 +808,36 @@ class TestErcot(BaseTestISO):
 
         self._check_unplanned_resource_outages(df)
 
-        assert df["Current As Of"].dt.date.unique() == [five_days_ago.date()]
-        # Publish Time is 3 days after the current as of time
-        assert df["Publish Time"].dt.date.unique() == [
-            (five_days_ago + pd.DateOffset(days=3)).date(),
+        assert df["Current As Of"].dt.date.unique() == [
+            (five_days_ago - pd.DateOffset(days=3)).date(),
         ]
+        assert df["Publish Time"].dt.date.unique() == [five_days_ago.date()]
 
     def test_get_unplanned_resource_outages_historical_range(self):
-        five_days_ago = self.local_start_of_today() - pd.DateOffset(days=5)
-        start = five_days_ago - pd.DateOffset(1)
+        start = self.local_start_of_today() - pd.DateOffset(6)
 
         df_2_days = self.iso.get_unplanned_resource_outages(
             start=start,
-            end=five_days_ago + pd.DateOffset(1),
+            end=start + pd.DateOffset(2),
         )
 
         self._check_unplanned_resource_outages(df_2_days)
 
         assert df_2_days["Current As Of"].dt.date.nunique() == 2
-        assert df_2_days["Current As Of"].min().date() == start.date()
-        assert df_2_days["Current As Of"].max().date() == five_days_ago.date()
+        assert (
+            df_2_days["Current As Of"].min().date()
+            == (start - pd.DateOffset(days=3)).date()
+        )
+        assert (
+            df_2_days["Current As Of"].max().date()
+            == (start - pd.DateOffset(days=2)).date()
+        )
 
         assert df_2_days["Publish Time"].dt.date.nunique() == 2
+        assert df_2_days["Publish Time"].min().date() == start.date()
+        assert (
+            df_2_days["Publish Time"].max().date() == (start + pd.DateOffset(1)).date()
+        )
 
     """test get_highest_price_as_offer_selected"""
 


### PR DESCRIPTION
- Updates `Ercot().get_unplanned_resource_outages()` to treat the `date` parameter as a filter on the publish date instead of the data date which required adding 3 days to given date
- This change gives more consistency across methods for datasets with a publish date
