### PR TITLE
Add retry to ErcotAPI.make_api_call().

### DIFF
--- a/gridstatus/tests/test_ercot_api.py
+++ b/gridstatus/tests/test_ercot_api.py
@@ -15,7 +15,7 @@ class TestErcotAPI(TestHelperMixin):
     def setup_class(cls):
         # https://docs.pytest.org/en/stable/how-to/xunit_setup.html
         # Runs before all tests in this class
-        cls.iso = ErcotAPI()
+        cls.iso = ErcotAPI(sleep_seconds=3, max_retries=5)
 
     """utils"""
 
@@ -911,7 +911,7 @@ class TestErcotAPI(TestHelperMixin):
 
         end_date = start_date + pd.DateOffset(days=2)
 
-        df = ErcotAPI(sleep_seconds=2.5).get_spp_real_time_15_min(
+        df = ErcotAPI(sleep_seconds=3.0, max_retries=5).get_spp_real_time_15_min(
             date=start_date,
             end=end_date,
             verbose=True,


### PR DESCRIPTION
## Fix issue #415 `ErcotAPI` not handling retries properly.

### Problem
When `ErcotAPI` makes requests to ERCOT too frequently, it would get a response with status code 429 (too many requests).  `ErcotAPI.hit_ercot_api()` delegates to `ErcotAPI.make_api_call()` which makes the call to ERCOT and it doesn't have any retry logic when the response has a status code of 429.  As a result, an exception is raised when it tries to access the data in the response.

### Solution
Add retry logic to `make_api_call` with the following changes:
- add `max_retries: int = 3` to constructor of ErcotAPI
- set `initial_delay` to `sleep_seconds' with min and max bounds
- set max_retries with min and max bounds
- add while loop for retrying with an exponential backoff strategy (doubling delay time in each retry iteration)
- raise error if response contains error or retries are exhausted

### Testing
Successfully downloaded 30 days dam_hourly_lmp by writing the one-day of data at a time (in a loop) with initial_delay = 1 second and max_retries = 5.

### Notes
There are retry handling outside of `make_api_call` method.  They are likely to be redundant after this change.
