### PR TITLE
Fix URL for ERCOT API registration instructions

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,7 +6,7 @@ PJM_API_KEY=
 
 # Register at https://data.ercot.com/ for username/password
 # and follow instructions at
-# https://developer.ercot.com/applications/pubapi/ERCOT%20Public%20API%20Registration%20and%20Authentication/
+# https://developer.ercot.com/applications/pubapi/user-guide/registration-and-authentication/
 # to get the subscription key
 ERCOT_API_USERNAME=
 ERCOT_API_PASSWORD=


### PR DESCRIPTION
The current URL in the comment is a dead link (404), updated it to the new URL for ERCOT's API registration and authentication page